### PR TITLE
fix postgres configration

### DIFF
--- a/docker.local/b0docker-compose.yml
+++ b/docker.local/b0docker-compose.yml
@@ -11,8 +11,6 @@ services:
       - ./blobber${BLOBBER}/data/postgresql:/var/lib/postgresql/data
     networks:
       default:
-    ports:
-      - "543${BLOBBER}:5432"
   postgres-post:
     image: postgres:11
     environment:

--- a/docker.local/p0docker-compose.yml
+++ b/docker.local/p0docker-compose.yml
@@ -11,8 +11,6 @@ services:
       - ./blobber${BLOBBER}/data/postgresql:/var/lib/postgresql/data
     networks:
       default:
-    ports:
-      - "543${BLOBBER}:5432"
   postgres-post:
     image: postgres:11
     environment:


### PR DESCRIPTION
remove ports definition for postgres instances in composer files. no need to proxy these ports externally, is available locally on the bridge.