### PR TITLE
Add github action for docker image build and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  [push]
+
+env:
+  BLOBBER_REGISTRY: ${{ secrets.BLOBBER_REGISTRY }}
+  VALIDATOR_REGISTRY: ${{ secrets.VALIDATOR_REGISTRY }}
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.14.x
+    - uses: actions/checkout@v2
+    - name: Test
+      run: |
+        for mod_file in $(find * -name go.mod); do
+            mod_dir=$(dirname $mod_file)
+            (cd $mod_dir; go test ./...)
+        done
+
+  dockerize_blobber:
+    runs-on: ubuntu-20.04
+    needs: test
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get the version
+      id: get_version
+      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+    - name: Build miner
+      run: |
+        docker build -t $BLOBBER_REGISTRY:$TAG -f docker.local/Dockerfile .
+        docker push $BLOBBER_REGISTRY:$TAG
+      env:
+        TAG: ${{ steps.get_version.outputs.VERSION }}
+
+  dockerize_validator:
+    runs-on: ubuntu-20.04
+    needs: test
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get the version
+      id: get_version
+      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+    - name: Build sharder
+      run: |
+        docker build -t $VALIDATOR_REGISTRY:$TAG -f docker.local/ValidatorDockerfile .
+        docker push $VALIDATOR_REGISTRY:$TAG
+      env:
+        TAG: ${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,7 @@ jobs:
         go-version: 1.14.x
     - uses: actions/checkout@v2
     - name: Test
-      run: |
-        for mod_file in $(find * -name go.mod); do
-            mod_dir=$(dirname $mod_file)
-            (cd $mod_dir; go test ./...)
-        done
+      run: bash ./test.sh
 
   dockerize_blobber:
     runs-on: ubuntu-20.04

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+for mod_file in $(find * -name go.mod); do
+    mod_dir=$(dirname $mod_file)
+    (cd $mod_dir; go test ./...)
+done


### PR DESCRIPTION
Blobber and validator docker images will be built and pushed to the docker hub when a new GitHub release is published.
The test will run before the image is built.

> The image tag will be the same as the tag that was used for the GitHub release

![image](https://user-images.githubusercontent.com/6071642/109844752-89824a80-7c74-11eb-905c-23461fc80767.png)
