### PR TITLE
Add BLS signature to metadata endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ ./docker.local/bin/build.blobber.sh
 ```
   
 
-3. After building the container for blobber, name the blobber by creating a directory with the given name eg. blobber1: (git/blobber/docker.local/blobber1). The blobber name must end in an integer. Then run the container using
+3. After building the container for blobber, name the blobber by creating a directory with the given name eg. blobber1: (git/blobber/docker.local/blobber1). The blobber name must end in an integer. Then cd into this directory and run the container using
 
   
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ ./docker.local/bin/build.blobber.sh
 ```
   
 
-3. After building the container for blobber, go to Blobber1 directory (git/blobber/docker.local/blobber1) and run the container using
+3. After building the container for blobber, name the blobber by creating a directory with the given name eg. blobber1: (git/blobber/docker.local/blobber1). The blobber name must end in an integer. Then run the container using
 
   
 

--- a/code/go/0chain.net/blobbercore/handler/storage_handler.go
+++ b/code/go/0chain.net/blobbercore/handler/storage_handler.go
@@ -128,6 +128,7 @@ func (fsh *StorageHandler) GetFileMeta(ctx context.Context, r *http.Request) (in
 	path_hash := r.FormValue("path_hash")
 
 	signatureValid, err := verifySignature(signature, clientPublicKey, authTokenString, path, path_hash)
+
 	if err != nil || !signatureValid {
 		return nil, common.NewError("invalid_parameters", "Invalid Signature")
 	}
@@ -702,7 +703,9 @@ func (fsh *StorageHandler) CalculateHash(ctx context.Context, r *http.Request) (
 }
 
 func verifySignature(signature string, publicKey string, hashParts ...string) (bool, error) {
-	hashData := strings.Join(hashParts, ":")
-	signatureHash := encryption.Hash(hashData)
-	return encryption.Verify(publicKey, signature, signatureHash)
+	if len(signature) < 64 {
+		return false, nil
+	}
+	hashData := encryption.Hash(strings.Join(hashParts, ":"))
+	return encryption.Verify(publicKey, signature, hashData)
 }

--- a/code/go/0chain.net/blobbercore/handler/storage_handler.go
+++ b/code/go/0chain.net/blobbercore/handler/storage_handler.go
@@ -122,10 +122,10 @@ func (fsh *StorageHandler) GetFileMeta(ctx context.Context, r *http.Request) (in
 		return nil, common.NewError("invalid_method", "Invalid method used. Use POST instead")
 	}
 	signature := r.FormValue("signature")
-	authTokenString := r.FormValue("auth_token")
-	path_hash := r.FormValue("path_hash")
-	path := r.FormValue("path")
 	clientPublicKey := ctx.Value(constants.CLIENT_KEY_CONTEXT_KEY).(string)
+	authTokenString := r.FormValue("auth_token")
+	path := r.FormValue("path")
+	path_hash := r.FormValue("path_hash")
 
 	signatureValid, err := verifySignature(signature, clientPublicKey, authTokenString, path, path_hash)
 	if err != nil || !signatureValid {

--- a/code/go/0chain.net/blobbercore/handler/storage_handler.go
+++ b/code/go/0chain.net/blobbercore/handler/storage_handler.go
@@ -127,8 +127,8 @@ func (fsh *StorageHandler) GetFileMeta(ctx context.Context, r *http.Request) (in
 	path := r.FormValue("path")
 	clientPublicKey := ctx.Value(constants.CLIENT_KEY_CONTEXT_KEY).(string)
 
-	hashValid, err := verifySignature(signature, clientPublicKey, authTokenString, path, path_hash)
-	if err != nil || !hashValid {
+	signatureValid, err := verifySignature(signature, clientPublicKey, authTokenString, path, path_hash)
+	if err != nil || !signatureValid {
 		return nil, common.NewError("invalid_parameters", "Invalid Signature")
 	}
 
@@ -471,6 +471,16 @@ func (fsh *StorageHandler) GetReferencePath(ctx context.Context, r *http.Request
 	allocationTx := ctx.Value(constants.ALLOCATION_CONTEXT_KEY).(string)
 	allocationObj, err := fsh.verifyAllocation(ctx, allocationTx, false)
 
+	signature := r.FormValue("signature")
+	path := r.FormValue("path")
+	pathsString := r.FormValue("paths")
+	clientPublicKey := ctx.Value(constants.CLIENT_KEY_CONTEXT_KEY).(string)
+
+	signatureValid, err := verifySignature(signature, clientPublicKey, path, pathsString)
+	if err != nil || !signatureValid {
+		return nil, common.NewError("invalid_parameters", "Invalid Signature")
+	}
+
 	if err != nil {
 		return nil, common.NewError("invalid_parameters", "Invalid allocation id passed."+err.Error())
 	}
@@ -482,7 +492,6 @@ func (fsh *StorageHandler) GetReferencePath(ctx context.Context, r *http.Request
 	}
 
 	var paths []string
-	pathsString := r.FormValue("paths")
 	if len(pathsString) == 0 {
 		path := r.FormValue("path")
 		if len(path) == 0 {

--- a/code/go/0chain.net/blobbercore/handler/storage_handler_test.go
+++ b/code/go/0chain.net/blobbercore/handler/storage_handler_test.go
@@ -1,0 +1,101 @@
+package handler
+
+import (
+	"0chain.net/blobbercore/constants"
+	"0chain.net/core/config"
+	"0chain.net/core/logging"
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestDoNotThrowInvalidSignatureErrorWhenSignatureValidForGivenRequestAndContext(t *testing.T) {
+	logging.InitLogging("development", "", "")
+	var blobber = &StorageHandler{}
+	var httpReq = &http.Request{}
+	httpReq.Form = url.Values{}
+	var ctx = httpReq.Context()
+
+	config.Configuration.SignatureScheme = "bls0chain"
+	httpReq.Form.Add("signature", "471e621e14f9cdb5acaeaebb42decc90be7a66852e851c89dc4d4ca857426d97")
+	httpReq.Form.Add("auth_token", "valid_auth_token")
+	httpReq.Form.Add("path", "expected_path")
+	httpReq.Form.Add("path_hash", "expected_haah")
+	ctx = context.WithValue(ctx, constants.CLIENT_CONTEXT_KEY, "valid_id")
+	ctx = context.WithValue(ctx, constants.CLIENT_KEY_CONTEXT_KEY, "de7c0361d75aa102821cba93863bdda39bae8aab94030130a61f660f2fb263049919cb8450d3772c8638a5d99f28497d53d6a6a01ae89865d4ec50405d1be380")
+
+	signatureValid := false
+	defer func() {
+		if err := recover(); err != nil {
+			signatureValid = true
+		}
+	}()
+	blobber.GetFileMeta(ctx, httpReq)
+
+	if !signatureValid {
+		t.Errorf("GetFileMeta() = expected vaid signature but was invalid")
+	}
+}
+
+func TestThrowInvalidSignatureErrorWhenSignatureInvalidForGivenRequestAndContextTooShort(t *testing.T) {
+	var blobber = &StorageHandler{}
+	var httpReq = &http.Request{}
+	httpReq.Form = url.Values{}
+	var ctx = httpReq.Context()
+
+	httpReq.Form.Add("signature", "invalid_signature")
+	httpReq.Form.Add("auth_token", "valid_auth_token")
+	httpReq.Form.Add("path", "expected_path")
+	httpReq.Form.Add("path_hash", "expected_haah")
+	ctx = context.WithValue(ctx, constants.CLIENT_CONTEXT_KEY, "valid_id")
+	ctx = context.WithValue(ctx, constants.CLIENT_KEY_CONTEXT_KEY, "e49946289899ee764f34f2c8890b37a481a431586f9a5dcb4cc4a85418e8820ff09a919ed6bb6afa255240859f7116c341907d16c3455489fbbca11788854e05")
+	_, err := blobber.GetFileMeta(ctx, httpReq)
+
+	var expectedErr = "invalid_parameters: Invalid Signature"
+	if err == nil {
+		t.Errorf("GetFileMeta() = expected error  but was %v", nil)
+	} else if err.Error() != expectedErr {
+		t.Errorf("GetFileMeta() = expected error message to be %v  but was %v", expectedErr, err.Error())
+	}
+}
+
+func TestThrowInvalidSignatureErrorWhenSignatureInvalidForGivenRequestAndContext(t *testing.T) {
+	var blobber = &StorageHandler{}
+	var httpReq = &http.Request{}
+	httpReq.Form = url.Values{}
+	var ctx = httpReq.Context()
+
+	httpReq.Form.Add("signature", "471e621e14f9cdb5acaeaebb42decc90be7a66852e851c89dc4d4ca857426d98")
+	httpReq.Form.Add("auth_token", "valid_auth_token")
+	httpReq.Form.Add("path", "expected_path")
+	httpReq.Form.Add("path_hash", "expected_haah")
+	ctx = context.WithValue(ctx, constants.CLIENT_CONTEXT_KEY, "valid_id")
+	ctx = context.WithValue(ctx, constants.CLIENT_KEY_CONTEXT_KEY, "e49946289899ee764f34f2c8890b37a481a431586f9a5dcb4cc4a85418e8820ff09a919ed6bb6afa255240859f7116c341907d16c3455489fbbca11788854e05")
+	_, err := blobber.GetFileMeta(ctx, httpReq)
+
+	var expectedErr = "invalid_parameters: Invalid Signature"
+	if err == nil {
+		t.Errorf("GetFileMeta() = expected error  but was %v", nil)
+	} else if err.Error() != expectedErr {
+		t.Errorf("GetFileMeta() = expected error message to be %v  but was %v", expectedErr, err.Error())
+	}
+}
+
+func TestThrowInvalidSignatureErrorWhenSignatureNotPresentForGivenRequestAndContext(t *testing.T) {
+	var blobber = &StorageHandler{}
+	var httpReq = &http.Request{}
+	httpReq.Form = url.Values{}
+	var ctx = httpReq.Context()
+
+	ctx = context.WithValue(ctx, constants.CLIENT_CONTEXT_KEY, "")
+	ctx = context.WithValue(ctx, constants.CLIENT_KEY_CONTEXT_KEY, "")
+	_, err := blobber.GetFileMeta(ctx, httpReq)
+
+	var expectedErr = "invalid_parameters: Invalid Signature"
+	if err == nil {
+		t.Errorf("GetFileMeta() = expected error  but was %v", nil)
+	} else if err.Error() != expectedErr {
+		t.Errorf("GetFileMeta() = expected error message to be %v  but was %v", expectedErr, err.Error())
+	}
+}


### PR DESCRIPTION
PR to resolve https://github.com/0chain/blobber/issues/48 
Validation:
Valid signature - current behaviour
Invalid/missing signature: 
![image](https://user-images.githubusercontent.com/18306778/113211416-59c36400-926d-11eb-8151-6e4fdfd8cb88.png)

/v1/file/referencepath/
Signature is added as a query param eg.
![image](https://user-images.githubusercontent.com/18306778/113211502-719ae800-926d-11eb-84f7-8d9b053bd900.png)
/v1/file/meta/ 
Signature is added as part of the multipart form.

I debated adding the signature as a header to keep things consistent across endpoints so I would be grateful for some input with regards to that

SDK changes to allow the clients to support this new requirement
https://github.com/0chain/gosdk/pull/26