### PR TITLE
hotfix

### DIFF
--- a/code/go/0chain.net/validatorcore/storage/writemarker/entity_test.go
+++ b/code/go/0chain.net/validatorcore/storage/writemarker/entity_test.go
@@ -120,21 +120,19 @@ func setupEntityTest(t *testing.T) (*writemarker.WriteMarker, *zcncrypto.Wallet,
 		Timestamp:              common.Now(),
 	}
 
+	// TODO: why the config param is not used here?
 	sigSch := zcncrypto.NewSignatureScheme("bls0chain")
 	wallet, err := sigSch.GenerateKeys()
 	if err != nil {
 		return wm, wallet, err
 	}
-	wm.ClientID = wallet.ClientID
 
-	err = sigSch.SetPrivateKey(wallet.Keys[0].PrivateKey)
-	if err != nil {
-		return wm, wallet, err
-	}
+	wm.ClientID = wallet.ClientID
 	sig, err := sigSch.Sign(encryption.Hash(wm.GetHashData()))
 	if err != nil {
 		return wm, wallet, err
 	}
+
 	wm.Signature = sig
 	return wm, wallet, nil
 }


### PR DESCRIPTION
@ronaudinho 
Please, review and merge asap.
The issue prevents other PRs to be merged.

PS. What was wrong:
```
wallet, err := sigSch.GenerateKeys()
```
This call already generates all the keys for sigSch struct - public and private. And there were no need to make an extra call to set private key. That excessive call produces the error and it was removed.


