### PR TITLE
Add geolocation fields to the config

### DIFF
--- a/code/go/0chain.net/blobbercore/config/config.go
+++ b/code/go/0chain.net/blobbercore/config/config.go
@@ -146,8 +146,8 @@ func Geolocation() GeolocationConfig {
 	g := Configuration.Geolocation
 	if g.Latitude > 90.00 || g.Latitude < -90.00 ||
 		g.Longitude > 180.00 || g.Longitude < -180.00 {
-			g.Latitude = float64(0.00)
-			g.Longitude = float64(0.00)
+			panic("Fatal error in config file")
+
 	}
 	return g
 }

--- a/code/go/0chain.net/blobbercore/config/config.go
+++ b/code/go/0chain.net/blobbercore/config/config.go
@@ -66,7 +66,6 @@ const (
 type GeolocationConfig struct {
 	Latitude float64 `mapstructure:"latitude"`
 	Longitude float64 `mapstructure:"longitude"`
-	// reserved / Accuracy float64 `mapstructure:"accuracy"`
 }
 
 type Config struct {

--- a/code/go/0chain.net/blobbercore/config/config.go
+++ b/code/go/0chain.net/blobbercore/config/config.go
@@ -141,6 +141,17 @@ func Development() bool {
 	return Configuration.DeploymentMode == DeploymentDevelopment
 }
 
+// get validated geolocatiion
+func Geolocation() GeolocationConfig {
+	g := Configuration.Geolocation
+	if g.Latitude > 90.00 || g.Latitude < -90.00 ||
+		g.Longitude > 180.00 || g.Longitude < -180.00 {
+			g.Latitude = float64(0.00)
+			g.Longitude = float64(0.00)
+	}
+	return g
+}
+
 /*ErrSupportedChain error for indicating which chain is supported by the server */
 var ErrSupportedChain error
 

--- a/code/go/0chain.net/blobbercore/config/config.go
+++ b/code/go/0chain.net/blobbercore/config/config.go
@@ -63,6 +63,12 @@ const (
 	DeploymentMainNet     = 2
 )
 
+type GeolocationConfig struct {
+	Latitude float64 `mapstructure:"latitude"`
+	Longitude float64 `mapstructure:"longitude"`
+	// reserved / Accuracy float64 `mapstructure:"accuracy"`
+}
+
 type Config struct {
 	*config.Config
 	DBHost                        string
@@ -118,6 +124,8 @@ type Config struct {
 	NumDelegates int `json:"num_delegates"`
 	// ServiceCharge for blobber.
 	ServiceCharge float64 `json:"service_charge"`
+
+	Geolocation GeolocationConfig `mapstructure:"geolocation"`
 }
 
 /*Configuration of the system */

--- a/code/go/0chain.net/blobbercore/handler/protocol.go
+++ b/code/go/0chain.net/blobbercore/handler/protocol.go
@@ -151,6 +151,7 @@ func getStorageNode() (*transaction.StorageNode, error) {
 	sn := &transaction.StorageNode{}
 	sn.ID = node.Self.ID
 	sn.BaseURL = node.Self.GetURLBase()
+	sn.Geolocation = config.Configuration.Geolocation
 	sn.Capacity = config.Configuration.Capacity
 	readPrice := config.Configuration.ReadPrice
 	writePrice := config.Configuration.WritePrice

--- a/code/go/0chain.net/blobbercore/handler/protocol.go
+++ b/code/go/0chain.net/blobbercore/handler/protocol.go
@@ -151,7 +151,7 @@ func getStorageNode() (*transaction.StorageNode, error) {
 	sn := &transaction.StorageNode{}
 	sn.ID = node.Self.ID
 	sn.BaseURL = node.Self.GetURLBase()
-	sn.Geolocation = config.Configuration.Geolocation
+	sn.Geolocation = config.Geolocation()
 	sn.Capacity = config.Configuration.Capacity
 	readPrice := config.Configuration.ReadPrice
 	writePrice := config.Configuration.WritePrice

--- a/code/go/0chain.net/blobbercore/handler/protocol.go
+++ b/code/go/0chain.net/blobbercore/handler/protocol.go
@@ -151,7 +151,7 @@ func getStorageNode() (*transaction.StorageNode, error) {
 	sn := &transaction.StorageNode{}
 	sn.ID = node.Self.ID
 	sn.BaseURL = node.Self.GetURLBase()
-	sn.Geolocation = config.Geolocation()
+	sn.Geolocation = transaction.StorageNodeGeolocation(config.Geolocation())
 	sn.Capacity = config.Configuration.Capacity
 	readPrice := config.Configuration.ReadPrice
 	writePrice := config.Configuration.WritePrice

--- a/code/go/0chain.net/blobbercore/readmarker/entity.go
+++ b/code/go/0chain.net/blobbercore/readmarker/entity.go
@@ -106,7 +106,6 @@ func GetLatestReadMarkerEntity(ctx context.Context, clientID string) (*ReadMarke
 }
 
 func SaveLatestReadMarker(ctx context.Context, rm *ReadMarker, isCreate bool) error {
-
 	var (
 		db       = datastore.GetStore().GetTransaction(ctx)
 		rmEntity = &ReadMarkerEntity{}

--- a/code/go/0chain.net/core/transaction/entity.go
+++ b/code/go/0chain.net/core/transaction/entity.go
@@ -68,13 +68,21 @@ type StakePoolSettings struct {
 	ServiceCharge float64 `json:"service_charge"`
 }
 
+// Move to the core one day
+type StorageNodeGeolocation struct {
+	Latitude float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+	// reserved / Accuracy float64 `mapstructure:"accuracy"`
+}
+
 type StorageNode struct {
-	ID                string            `json:"id"`
-	BaseURL           string            `json:"url"`
-	Terms             Terms             `json:"terms"`
-	Capacity          int64             `json:"capacity"`
-	PublicKey         string            `json:"-"`
-	StakePoolSettings StakePoolSettings `json:"stake_pool_settings"`
+	ID                string                 `json:"id"`
+	BaseURL           string                 `json:"url"`
+	Geolocation       StorageNodeGeolocation `json:"geolocation"`
+	Terms             Terms                  `json:"terms"`
+	Capacity          int64                  `json:"capacity"`
+	PublicKey         string                 `json:"-"`
+	StakePoolSettings StakePoolSettings      `json:"stake_pool_settings"`
 }
 
 type BlobberAllocation struct {

--- a/code/go/0chain.net/core/transaction/entity.go
+++ b/code/go/0chain.net/core/transaction/entity.go
@@ -68,11 +68,9 @@ type StakePoolSettings struct {
 	ServiceCharge float64 `json:"service_charge"`
 }
 
-// Move to the core one day
 type StorageNodeGeolocation struct {
 	Latitude float64 `json:"latitude"`
 	Longitude float64 `json:"longitude"`
-	// reserved / Accuracy float64 `mapstructure:"accuracy"`
 }
 
 type StorageNode struct {

--- a/config/0chain_blobber.yaml
+++ b/config/0chain_blobber.yaml
@@ -87,6 +87,10 @@ db:
   host: postgres
   port: 5432
 
+geolocation:
+  latitude: 0
+  longitude: 0
+
 minio:
   # Enable or disable minio backup service
   start: false


### PR DESCRIPTION
@Sriep 
Need you input. Thanks.

- how about to move the GeolocationConfig struct to 0chain main app, specifically here (and import from there to specific services, such as blobber):
https://github.com/0chain/0chain/blob/master/code/go/0chain.net/chaincore/config/config.go

- it was also mentioned to add geolocation props to storagsc and minersc smart contracts too. does it mean, the props should be added to these structs specifically (currently they have near to zero fields)?
https://github.com/0chain/0chain/blob/ee5704d2617f42dcf857270cf73be44a9e5c523b/code/go/0chain.net/smartcontract/storagesc/sc.go#L24
https://github.com/0chain/0chain/blob/ee5704d2617f42dcf857270cf73be44a9e5c523b/code/go/0chain.net/smartcontract/minersc/sc.go#L51
 
