### PR TITLE
set CORS allow origin * in the right place

### DIFF
--- a/code/go/0chain.net/blobber/main.go
+++ b/code/go/0chain.net/blobber/main.go
@@ -335,7 +335,11 @@ func main() {
 		"X-Requested-With", "X-App-Client-ID",
 		"X-App-Client-Key", "Content-Type",
 	})
-	originsOk := handlers.AllowedOriginValidator(isValidOrigin)
+
+	// Allow anybody to access API.
+	// originsOk := handlers.AllowedOriginValidator(isValidOrigin)
+	originsOk := handlers.AllowedOrigins([]string{"*"})
+
 	methodsOk := handlers.AllowedMethods([]string{"GET", "HEAD", "POST", "PUT",
 		"DELETE", "OPTIONS"})
 

--- a/code/go/0chain.net/blobber/main.go
+++ b/code/go/0chain.net/blobber/main.go
@@ -8,11 +8,9 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"runtime"
 	"strconv"
-	"strings"
 	"time"
 
 	"0chain.net/blobbercore/allocation"

--- a/code/go/0chain.net/blobber/main.go
+++ b/code/go/0chain.net/blobber/main.go
@@ -193,25 +193,27 @@ func processMinioConfig(reader io.Reader) error {
 	return nil
 }
 
-func isValidOrigin(origin string) bool {
-	var url, err = url.Parse(origin)
-	if err != nil {
-		return false
-	}
-	var host = url.Hostname()
-	if host == "localhost" {
-		return true
-	}
-	if host == "0chain.net" || host == "0box.io" ||
-		strings.HasSuffix(host, ".0chain.net") ||
-		strings.HasSuffix(host, ".alphanet-0chain.net") ||
-		strings.HasSuffix(host, ".testnet-0chain.net") ||
-		strings.HasSuffix(host, ".devnet-0chain.net") ||
-		strings.HasSuffix(host, ".mainnet-0chain.net") {
-		return true
-	}
-	return false
-}
+// // Comment out to pass lint. Still keep this function around in case we want to
+// // change how CORS validates origins.
+// func isValidOrigin(origin string) bool {
+// 	var url, err = url.Parse(origin)
+// 	if err != nil {
+// 		return false
+// 	}
+// 	var host = url.Hostname()
+// 	if host == "localhost" {
+// 		return true
+// 	}
+// 	if host == "0chain.net" || host == "0box.io" ||
+// 		strings.HasSuffix(host, ".0chain.net") ||
+// 		strings.HasSuffix(host, ".alphanet-0chain.net") ||
+// 		strings.HasSuffix(host, ".testnet-0chain.net") ||
+// 		strings.HasSuffix(host, ".devnet-0chain.net") ||
+// 		strings.HasSuffix(host, ".mainnet-0chain.net") {
+// 		return true
+// 	}
+// 	return false
+// }
 
 func main() {
 	deploymentMode := flag.Int("deployment_mode", 2, "deployment_mode")


### PR DESCRIPTION
sry about that. I didn't properly test last time. I tested it properly this time.

How to test
1. setup blobber to run on localhost as instructed in README.
2. Run this curl:

```
  curl -i 'http://localhost:5051/v1/file/upload/4e863327cf888dfd6ae87ebc7dbd6771741a4d7a0288527f213dd9a243dffad4' \
    -X 'OPTIONS' \
    -H 'Accept: */*' \
    -H 'Access-Control-Request-Method: POST' \
    -H 'Access-Control-Request-Headers: x-app-client-id,x-app-client-key' \
    -H 'Origin: http://localhost:82' \
    -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36' \
    -H 'Sec-Fetch-Mode: cors' \
    --compressed
```

Expect this output:
```
HTTP/1.1 200 OK
Access-Control-Allow-Headers: X-App-Client-Id,X-App-Client-Key
Access-Control-Allow-Origin: *
Date: Sun, 23 May 2021 00:50:00 GMT
Content-Length: 0
```