### PR TITLE
Workaround for double registration for restarted blobbers

### DIFF
--- a/code/go/0chain.net/blobbercore/handler/protocol.go
+++ b/code/go/0chain.net/blobbercore/handler/protocol.go
@@ -82,8 +82,8 @@ func RegisterBlobber(ctx context.Context) (string, error) {
 
 	for _, sRegisteredNode := range sRegisteredNodes {
 		if sn.ID == string(sRegisteredNode.ID) || sn.BaseURL == sRegisteredNode.BaseURL {
-			Logger.Info("Failed during registering blobber to the mining network, it's duplicated")
-			// should return valid transcation hash, notan error
+			Logger.Info("Warning: blobber already registered to the mining network. Updating blobber settings.")
+			// should return valid transcation hash, not an error
 			// (see: "restarted blobbers" case)
 			return UpdateBlobberSettings(ctx)
 		}

--- a/code/go/0chain.net/blobbercore/handler/protocol.go
+++ b/code/go/0chain.net/blobbercore/handler/protocol.go
@@ -83,7 +83,9 @@ func RegisterBlobber(ctx context.Context) (string, error) {
 	for _, sRegisteredNode := range sRegisteredNodes {
 		if sn.ID == string(sRegisteredNode.ID) || sn.BaseURL == sRegisteredNode.BaseURL {
 			Logger.Info("Failed during registering blobber to the mining network, it's duplicated")
-			return "", errors.New("Duplicated")
+			// should return valid transcation hash, notan error
+			// (see: "restarted blobbers" case)
+			return UpdateBlobberSettings(ctx)
 		}
 	}
 


### PR DESCRIPTION
To return valid hash, not an error.
To prevent issues during re-registration requests from restarted blobbers.