### PR TITLE
sql to increase client_public_key from 256 to 512

### DIFF
--- a/sql/14-increase_owner_pubkey.sql
+++ b/sql/14-increase_owner_pubkey.sql
@@ -9,4 +9,6 @@
 BEGIN;
     ALTER TABLE allocations
         ALTER COLUMN owner_public_key TYPE varchar(512);
+    ALTER TABLE read_markers
+        ALTER COLUMN client_public_key TYPE varchar(512);
 COMMIT;


### PR DESCRIPTION
still seeing issue #178, I think I missed this SQL field, which is also for public keys and needs to handle MIRACL public key sizes of 258 bytes.