### PR TITLE
increase write_markers.client_key size

### DIFF
--- a/sql/14-increase_owner_pubkey.sql
+++ b/sql/14-increase_owner_pubkey.sql
@@ -11,4 +11,6 @@ BEGIN;
         ALTER COLUMN owner_public_key TYPE varchar(512);
     ALTER TABLE read_markers
         ALTER COLUMN client_public_key TYPE varchar(512);
+    ALTER TABLE write_markers
+        ALTER COLUMN client_key TYPE varchar(512);
 COMMIT;


### PR DESCRIPTION
still seeing issue #178 , client_key is also a public key even though it doesn't have the "pub" keyword in it