### PR TITLE
Update worker.go

### DIFF
--- a/code/go/0chain.net/blobbercore/challenge/worker.go
+++ b/code/go/0chain.net/blobbercore/challenge/worker.go
@@ -49,7 +49,6 @@ func SubmitProcessedChallenges(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			Logger.Info("Attempting to commit processed challenges...")
 			rctx := datastore.GetStore().CreateTransaction(ctx)
 			db := datastore.GetStore().GetTransaction(rctx)
 			//lastChallengeRedeemed := &ChallengeEntity{}


### PR DESCRIPTION
To remove misleading log message, that is placed before the process pre-starting conditions. So in cases when the conditions are not met, the message becomes misleading. The actual challenges committing process starts down the code. And already contains logging instructions.