### PR TITLE
Add postman API tests to CI workflow (requires secrets + github pages)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,4 +128,53 @@ jobs:
         docker build -t $VALIDATOR_REGISTRY:$TAG -f docker.local/ValidatorDockerfile .
         docker push $VALIDATOR_REGISTRY:$TAG
       env:
-        TAG: ${{ steps.get_version.outputs.VERSION }}
+        TAG: ${{ steps.get_version.outputs.VERSION }} 
+ 
+  api_tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          repository: 0chain/0chainAPI
+          token: ${{ secrets.PERSONAL_SECRET }}
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with: 
+          node-version: '12.x'
+
+      - name: Install newman
+        run: |
+         npm install -g newman
+         npm install -g newman-reporter-htmlextra
+         
+      - name: Set env BRANCH
+        run: echo "BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)" >> $GITHUB_ENV    
+
+      - name: Make Directory for results
+        run: mkdir -p ./${BRANCH}
+
+      - name: Run POSTMAN collection
+        run: |
+           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/Testnet.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/index.html" --reporter-htmlextra-darkTheme --color on  
+    
+      - name: Output the run Details
+        if: always()
+        uses: actions/upload-artifact@v2
+        with: 
+         name: RunReports
+         path: "./${{ env.BRANCH }}"
+         
+      - name: Deploy report page
+        if: always()
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.PERSONAL_SECRET }}
+          publish_dir: "./${{ env.BRANCH }}"
+          destination_dir: "./${{ env.BRANCH }}"
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'    
+          
+      - name: Report Link
+        if: always()
+        run: echo "https://stewartie4.github.io/blobber/${{ env.BRANCH }}" 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Run POSTMAN collection
         run: |
            exit_code=0
-           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/latest/index.html" --reporter-htmlextra-darkTheme --reporter-htmlextra-showEnvironmentData --reporter-htmlextra-showGlobalData --reporter-htmlextra-browserTitle "0Chain regressions for ${GITHUB_SHA}" --reporter-htmlextra-title "0Chain API Regression Tests" --reporter-htmlextra-template "./Postman Collections/Data/0chain-dashboard-template.hbs" --env-var "commit-hash=${GITHUB_SHA}" --color on || exit_code=$? 
+           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/latest/index.html" --reporter-htmlextra-darkTheme --reporter-htmlextra-showEnvironmentData --reporter-htmlextra-showGlobalData --reporter-htmlextra-browserTitle "0Chain regressions for ${GITHUB_SHA}" --reporter-htmlextra-title "0Chain API Regression Tests" --reporter-htmlextra-template "./Postman Collections/Data/0chain-dashboard-template.hbs" --reporter-htmlextra-commit-hash ${GITHUB_SHA} --color on || exit_code=$? 
            cp -R ./${BRANCH}/latest ./${BRANCH}/${GITHUB_SHA}
            exit $exit_code
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,14 +152,15 @@ jobs:
         run: echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV
 
       - name: Make Directory for results
-        run: |
-         mkdir -p ./${BRANCH}/latest
-         ln -snf ./${BRANCH}/latest ./${BRANCH}/${GITHUB_SHA}
+        run: mkdir -p ./${BRANCH}/latest
          
 
       - name: Run POSTMAN collection
         run: |
-           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/latest/index.html" --reporter-htmlextra-darkTheme --color on  
+           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/latest/index.html" --reporter-htmlextra-darkTheme --color on; 
+           ret=$?; 
+           cp -R ./${BRANCH}/latest ./${BRANCH}/${GITHUB_SHA}; 
+           exit $ret  
     
       - name: Output the run Details
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Run POSTMAN collection
         run: |
            exit_code=0
-           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/latest/index.html" --reporter-htmlextra-darkTheme --reporter-htmlextra-showEnvironmentData --reporter-htmlextra-showGlobalData --reporter-htmlextra-browserTitle "0Chain regressions for ${GITHUB_SHA}" --reporter-htmlextra-title "0Chain API Regression Tests" --color on || exit_code=$? 
+           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/latest/index.html" --reporter-htmlextra-darkTheme --reporter-htmlextra-showEnvironmentData --reporter-htmlextra-showGlobalData --reporter-htmlextra-browserTitle "0Chain regressions for ${GITHUB_SHA}" --reporter-htmlextra-title "0Chain API Regression Tests" --reporter-htmlextra-template "./Postman Collections/Data/0chain-dashboard-template.hbs" --env-var "commit-hash=${GITHUB_SHA}" --color on || exit_code=$? 
            cp -R ./${BRANCH}/latest ./${BRANCH}/${GITHUB_SHA}
            exit $exit_code
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
         with:
           repository: 0chain/0chainAPI
           token: ${{ secrets.SVC_ACCOUNT_SECRET }}
+          
       - name: Install Node
         uses: actions/setup-node@v1
         with: 
@@ -155,7 +156,6 @@ jobs:
 
       - name: Make Directory for results
         run: mkdir -p ./${BRANCH}/latest
-         
 
       - name: Run POSTMAN collection
         run: |
@@ -177,11 +177,11 @@ jobs:
         with:
           publish_branch: test_reports
           keep_files: true
-          github_token: ${{ secrets.SVC_ACCOUNT_SECRET }}
+          github_token: "${{ secrets.SVC_ACCOUNT_SECRET }}"
           publish_dir: "./${{ env.BRANCH }}"
           destination_dir: "./${{ env.BRANCH }}"
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'    
+          user_name: "github-actions[bot]"
+          user_email: "github-actions[bot]@users.noreply.github.com"    
           
       - name: Report Link
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Set env BRANCH
         run: |
          echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV
-         echo "BRANCH_UNSANITIZED=$(echo ${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+         echo "BRANCH_UNSANITIZED=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
 
       - name: Make Directory for results
         run: mkdir -p ./${BRANCH}/latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,18 +152,18 @@ jobs:
         run: echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV    
 
       - name: Make Directory for results
-        run: mkdir -p ./${BRANCH}
+        run: mkdir -p ./${BRANCH}/${{ github.run_number }}
 
       - name: Run POSTMAN collection
         run: |
-           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/index.html" --reporter-htmlextra-darkTheme --color on  
+           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/${{ github.run_number }}/index.html" --reporter-htmlextra-darkTheme --color on  
     
       - name: Output the run Details
         if: always()
         uses: actions/upload-artifact@v2
         with: 
          name: RunReports
-         path: "./${{ env.BRANCH }}"
+         path: "./${{ env.BRANCH }}/${{ github.run_number }}"
          
       - name: Deploy report page
         if: always()
@@ -177,4 +177,4 @@ jobs:
           
       - name: Report Link
         if: always()
-        run: echo "https://0chain.github.io/blobber/${{ env.BRANCH }}" 
+        run: echo "https://0chain.github.io/blobber/${{ env.BRANCH }}/${{ github.run_number }}" 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
         if: always()
         uses: peaceiris/actions-gh-pages@v3
         with:
+          keep_files: true
           github_token: ${{ secrets.SVC_ACCOUNT_SECRET }}
           publish_dir: "./${{ env.BRANCH }}"
           destination_dir: "./${{ env.BRANCH }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Run POSTMAN collection
         run: |
            exit_code=0
-           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/latest/index.html" --reporter-htmlextra-darkTheme --color on || exit_code=$? 
+           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/latest/index.html" --reporter-htmlextra-darkTheme --reporter-htmlextra-showEnvironmentData --reporter-htmlextra-timezone --reporter-htmlextra-showGlobalData --reporter-htmlextra-browserTitle "0Chain regressions for ${GITHUB_SHA}" --reporter-htmlextra-title "0Chain API Regression Tests" --color on || exit_code=$? 
            cp -R ./${BRANCH}/latest ./${BRANCH}/${GITHUB_SHA}
            exit $exit_code
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,10 +157,10 @@ jobs:
 
       - name: Run POSTMAN collection
         run: |
-           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/latest/index.html" --reporter-htmlextra-darkTheme --color on; 
-           ret=$?; 
-           cp -R ./${BRANCH}/latest ./${BRANCH}/${GITHUB_SHA}; 
-           exit $ret  
+           exit_code=0
+           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/latest/index.html" --reporter-htmlextra-darkTheme --color on || exit_code=$? 
+           cp -R ./${BRANCH}/latest ./${BRANCH}/${GITHUB_SHA}
+           exit $exit_code  
     
       - name: Output the run Details
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Set env BRANCH
         run: |
          echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV
-         echo "BRANCH_UNSANITIZED=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV
+         echo "BRANCH_UNSANITIZED=$(echo ${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
 
       - name: Make Directory for results
         run: mkdir -p ./${BRANCH}/latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Run POSTMAN collection
         run: |
            exit_code=0
-           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/latest/index.html" --reporter-htmlextra-darkTheme --reporter-htmlextra-showEnvironmentData --reporter-htmlextra-timezone --reporter-htmlextra-showGlobalData --reporter-htmlextra-browserTitle "0Chain regressions for ${GITHUB_SHA}" --reporter-htmlextra-title "0Chain API Regression Tests" --color on || exit_code=$? 
+           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/latest/index.html" --reporter-htmlextra-darkTheme --reporter-htmlextra-showEnvironmentData --reporter-htmlextra-showGlobalData --reporter-htmlextra-browserTitle "0Chain regressions for ${GITHUB_SHA}" --reporter-htmlextra-title "0Chain API Regression Tests" --color on || exit_code=$? 
            cp -R ./${BRANCH}/latest ./${BRANCH}/${GITHUB_SHA}
            exit $exit_code
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 0chain/0chainAPI
-          token: ${{ secrets.PERSONAL_SECRET }}
+          token: ${{ secrets.SVC_ACCOUNT_SECRET }}
       - name: Install Node
         uses: actions/setup-node@v1
         with: 
@@ -169,7 +169,7 @@ jobs:
         if: always()
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.PERSONAL_SECRET }}
+          github_token: ${{ secrets.SVC_ACCOUNT_SECRET }}
           publish_dir: "./${{ env.BRANCH }}"
           destination_dir: "./${{ env.BRANCH }}"
           user_name: 'github-actions[bot]'
@@ -177,4 +177,4 @@ jobs:
           
       - name: Report Link
         if: always()
-        run: echo "https://stewartie4.github.io/blobber/${{ env.BRANCH }}" 
+        run: echo "https://0chain.github.io/blobber/${{ env.BRANCH }}" 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
         if: always()
         uses: peaceiris/actions-gh-pages@v3
         with:
+          publish_branch: test_reports
           keep_files: true
           github_token: ${{ secrets.SVC_ACCOUNT_SECRET }}
           publish_dir: "./${{ env.BRANCH }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Run POSTMAN collection
         run: |
            exit_code=0
-           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/latest/index.html" --reporter-htmlextra-darkTheme --reporter-htmlextra-showEnvironmentData --reporter-htmlextra-showGlobalData --reporter-htmlextra-browserTitle "0Chain regressions for ${GITHUB_SHA}" --reporter-htmlextra-title "0Chain API Regression Tests" --reporter-htmlextra-template "./Postman Collections/Data/0chain-dashboard-template.hbs" --reporter-htmlextra-commit-hash ${GITHUB_SHA} --color on || exit_code=$? 
+           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/latest/index.html" --reporter-htmlextra-darkTheme --reporter-htmlextra-showEnvironmentData --reporter-htmlextra-showGlobalData --reporter-htmlextra-browserTitle "${GITHUB_SHA}" --reporter-htmlextra-title "0Chain API Regression Tests" --reporter-htmlextra-template "./Postman Collections/Data/0chain-dashboard-template.hbs"  --color on || exit_code=$? 
            cp -R ./${BRANCH}/latest ./${BRANCH}/${GITHUB_SHA}
            exit $exit_code
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
          npm install -g newman-reporter-htmlextra
          
       - name: Set env BRANCH
-        run: echo "BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)" >> $GITHUB_ENV    
+        run: echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV    
 
       - name: Make Directory for results
         run: mkdir -p ./${BRANCH}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,21 +149,24 @@ jobs:
          npm install -g newman-reporter-htmlextra
          
       - name: Set env BRANCH
-        run: echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV    
+        run: echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV
 
       - name: Make Directory for results
-        run: mkdir -p ./${BRANCH}/${{ github.run_number }}
+        run: |
+         mkdir -p ./${BRANCH}/latest
+         ln -snf ./${BRANCH}/latest ./${BRANCH}/${GITHUB_SHA}
+         
 
       - name: Run POSTMAN collection
         run: |
-           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/${{ github.run_number }}/index.html" --reporter-htmlextra-darkTheme --color on  
+           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/latest/index.html" --reporter-htmlextra-darkTheme --color on  
     
       - name: Output the run Details
         if: always()
         uses: actions/upload-artifact@v2
         with: 
          name: RunReports
-         path: "./${{ env.BRANCH }}/${{ github.run_number }}"
+         path: "./${{ env.BRANCH }}/latest"
          
       - name: Deploy report page
         if: always()
@@ -177,4 +180,4 @@ jobs:
           
       - name: Report Link
         if: always()
-        run: echo "https://0chain.github.io/blobber/${{ env.BRANCH }}/${{ github.run_number }}" 
+        run: echo "https://0chain.github.io/blobber/${{ env.BRANCH }}/${GITHUB_SHA}" 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,9 @@ jobs:
          npm install -g newman-reporter-htmlextra
          
       - name: Set env BRANCH
-        run: echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV
+        run: |
+         echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV
+         echo "BRANCH_UNSANITIZED=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV
 
       - name: Make Directory for results
         run: mkdir -p ./${BRANCH}/latest
@@ -158,7 +160,7 @@ jobs:
       - name: Run POSTMAN collection
         run: |
            exit_code=0
-           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/latest/index.html" --reporter-htmlextra-darkTheme --reporter-htmlextra-showEnvironmentData --reporter-htmlextra-showGlobalData --reporter-htmlextra-browserTitle "${GITHUB_SHA}" --reporter-htmlextra-title "0Chain API Regression Tests" --reporter-htmlextra-template "./Postman Collections/Data/0chain-dashboard-template.hbs"  --color on || exit_code=$? 
+           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/latest/index.html" --reporter-htmlextra-darkTheme --reporter-htmlextra-showEnvironmentData --reporter-htmlextra-showGlobalData --reporter-htmlextra-browserTitle "${GITHUB_SHA} on branch ${BRANCH_UNSANITIZED}" --reporter-htmlextra-title "0Chain API Regression Tests" --reporter-htmlextra-template "./Postman Collections/Data/0chain-dashboard-template.hbs"  --color on || exit_code=$? 
            cp -R ./${BRANCH}/latest ./${BRANCH}/${GITHUB_SHA}
            exit $exit_code
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Run POSTMAN collection
         run: |
-           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/Testnet.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/index.html" --reporter-htmlextra-darkTheme --color on  
+           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.SVC_ACCOUNT_SECRET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/index.html" --reporter-htmlextra-darkTheme --color on  
     
       - name: Output the run Details
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Run POSTMAN collection
         run: |
-           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.SVC_ACCOUNT_SECRET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/index.html" --reporter-htmlextra-darkTheme --color on  
+           newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/index.html" --reporter-htmlextra-darkTheme --color on  
     
       - name: Output the run Details
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
            exit_code=0
            newman run "./Postman Collections/0chain-regressions.json" -e "./Postman Collections/Environments/${{ secrets.TEMP_API_TESTNET_TARGET }}.postman_environment.json" -r cli,htmlextra --reporter-htmlextra-export "./${BRANCH}/latest/index.html" --reporter-htmlextra-darkTheme --color on || exit_code=$? 
            cp -R ./${BRANCH}/latest ./${BRANCH}/${GITHUB_SHA}
-           exit $exit_code  
+           exit $exit_code
     
       - name: Output the run Details
         if: always()


### PR DESCRIPTION
This change will
1. Install Newman (postman collection runner)
2. Checkout the postman regression collection 
3. Run tests against a configured endpoint (for now hardcoded to devnet, later will be k8s cluster that has just been deployed to)
4. publish a test report via an HTML link 
branch prefix followed by the commit sha for a perma link
https://0chain.github.io/blobber/feature_add-api-regressions-to-ci/7ab72afa87f12c38c1595797e150267010c309c4/
and /latest/ for a symlink
https://0chain.github.io/blobber/feature_add-api-regressions-to-ci/latest/
5. Publish a zip file report
6. fail the build if the tests fail