### PR TITLE
Use rx_pay on auth ticket only

### DIFF
--- a/code/go/0chain.net/blobbercore/handler/object_operation_handler.go
+++ b/code/go/0chain.net/blobbercore/handler/object_operation_handler.go
@@ -274,16 +274,11 @@ func (fsh *StorageHandler) DownloadFile(ctx context.Context, r *http.Request) (
 		payerID = alloc.PayerID
 	}
 
-	// set payer: check for command line payer flag (--rx_pay)
-	if r.FormValue("rx_pay") == "true" {
-		payerID = clientID
-	}
-
 	// authorize file access
 	var (
-		isOwner          = clientID == alloc.OwnerID
-		isRepairer       = clientID == alloc.RepairerID
-		isCollaborator   = reference.IsACollaborator(ctx, fileref.ID, clientID)
+		isOwner        = clientID == alloc.OwnerID
+		isRepairer     = clientID == alloc.RepairerID
+		isCollaborator = reference.IsACollaborator(ctx, fileref.ID, clientID)
 	)
 
 	if !isOwner && !isRepairer && !isCollaborator {
@@ -295,6 +290,11 @@ func (fsh *StorageHandler) DownloadFile(ctx context.Context, r *http.Request) (
 		); !isAuthorized {
 			return nil, common.NewErrorf("download_file",
 				"cannot verify auth ticket: %v", err)
+		}
+
+		// set payer: check for command line payer flag (--rx_pay)
+		if r.FormValue("rx_pay") == "true" {
+			payerID = clientID
 		}
 
 		if json.Unmarshal([]byte(authTokenString), &readmarker.AuthTicket{}) != nil {


### PR DESCRIPTION
The rx_pay is a boolean field that indicates whether the client or owner should pay.

Currently, rx_pay is affecting all `download` transactions. Changed so it is only checked when using aut ticket.

Part of issue https://github.com/0chain/blobber/issues/236