### PR TITLE
fix(docker):stop to expose port for postgres

### DIFF
--- a/docker.local/b0docker-compose.yml
+++ b/docker.local/b0docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
-      - "5432:5432"
+      # - "5432:5432"
     volumes:
       - ./blobber${BLOBBER}/data/postgresql:/var/lib/postgresql/data
     networks:


### PR DESCRIPTION
the port of postgres can't be exposed. if not, only one blobber can be started.