### PR TITLE
added renameObjectResponse Handler in blobbercore convert

### DIFF
--- a/code/go/0chain.net/blobbercore/convert/response_handler.go
+++ b/code/go/0chain.net/blobbercore/convert/response_handler.go
@@ -160,3 +160,14 @@ func CopyObjectResponseHandler(copyObjectResponse *blobbergrpc.CopyObjectRespons
 		UploadOffset: copyObjectResponse.UploadOffset,
 	}
 }
+
+func RenameObjectResponseHandler(renameObjectResponse *blobbergrpc.RenameObjectResponse) *blobberhttp.UploadResult {
+	return &blobberhttp.UploadResult{
+		Filename:     renameObjectResponse.Filename,
+		Size:         renameObjectResponse.Size,
+		Hash:         renameObjectResponse.ContentHash,
+		MerkleRoot:   renameObjectResponse.MerkleRoot,
+		UploadLength: renameObjectResponse.UploadLength,
+		UploadOffset: renameObjectResponse.UploadOffset,
+	}
+}


### PR DESCRIPTION
Need this for the support for converting renameObjectResponse for GRPC to http response. 

The issue: https://github.com/0chain/gosdk/issues/137

The PR: https://github.com/0chain/gosdk/pull/183