### PR TITLE
:bug: Error sharing files with wrong clientID

### DIFF
--- a/code/go/0chain.net/blobbercore/handler/handler.go
+++ b/code/go/0chain.net/blobbercore/handler/handler.go
@@ -452,10 +452,6 @@ func InsertShare(ctx context.Context, r *http.Request) (interface{}, error) {
 		return nil, common.NewError("share_info_insert", "Wrong ownerID or clientID")
 	}
 
-	if allocationObj.OwnerID != authTicket.OwnerID {
-		return nil, common.NewError("share_info_insert", "Wrong owner of allocation")
-	}
-
 	shareInfo := reference.ShareInfo{
 		OwnerID:                   authTicket.OwnerID,
 		ClientID:                  authTicket.ClientID,

--- a/code/go/0chain.net/blobbercore/handler/handler.go
+++ b/code/go/0chain.net/blobbercore/handler/handler.go
@@ -447,6 +447,15 @@ func InsertShare(ctx context.Context, r *http.Request) (interface{}, error) {
 		return nil, err
 	}
 
+	// dummy, to avoid input and sql error
+	if len(authTicket.ClientID) != 64 || len(authTicket.OwnerID) != 64 {
+		return nil, common.NewError("share_info_insert", "Wrong ownerID or clientID")
+	}
+
+	if allocationObj.OwnerID != authTicket.OwnerID {
+		return nil, common.NewError("share_info_insert", "Wrong owner of allocation")
+	}
+
 	shareInfo := reference.ShareInfo{
 		OwnerID:                   authTicket.OwnerID,
 		ClientID:                  authTicket.ClientID,
@@ -464,7 +473,7 @@ func InsertShare(ctx context.Context, r *http.Request) (interface{}, error) {
 		err = reference.AddShareInfo(ctx, shareInfo)
 	}
 	if err != nil {
-		return nil, err
+		return nil, common.NewError("share_info_insert", "Unable to save share info")
 	}
 
 	resp := map[string]interface{}{

--- a/code/go/0chain.net/blobbercore/handler/handler_test.go
+++ b/code/go/0chain.net/blobbercore/handler/handler_test.go
@@ -1188,12 +1188,12 @@ func TestHandlers_Requiring_Signature(t *testing.T) {
 					)
 
 				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "marketplace_share_info" WHERE`)).
-					WithArgs("abcdefgh", "f15383a1130bd2fae1e52a7a15c432269eeb7def555f1f8b9b9a28bd9611362c").
+					WithArgs("da4b54d934890aa415bb043ce1126f2e30a96faf63a4c65c25bbddcb32824d77", "f15383a1130bd2fae1e52a7a15c432269eeb7def555f1f8b9b9a28bd9611362c").
 					WillReturnRows(sqlmock.NewRows([]string{}))
 				aa := sqlmock.AnyArg()
 
 				mock.ExpectExec(`INSERT INTO "marketplace_share_info"`).
-					WithArgs(client.GetClientID(), "abcdefgh", "f15383a1130bd2fae1e52a7a15c432269eeb7def555f1f8b9b9a28bd9611362c", "regenkey", aa, false, aa).
+					WithArgs(client.GetClientID(), "da4b54d934890aa415bb043ce1126f2e30a96faf63a4c65c25bbddcb32824d77", "f15383a1130bd2fae1e52a7a15c432269eeb7def555f1f8b9b9a28bd9611362c", "regenkey", aa, false, aa).
 					WillReturnResult(sqlmock.NewResult(0, 0))
 			},
 			wantCode: http.StatusOK,
@@ -1276,7 +1276,7 @@ func TestHandlers_Requiring_Signature(t *testing.T) {
 					)
 
 				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "marketplace_share_info" WHERE`)).
-					WithArgs("abcdefgh", "f15383a1130bd2fae1e52a7a15c432269eeb7def555f1f8b9b9a28bd9611362c").
+					WithArgs("da4b54d934890aa415bb043ce1126f2e30a96faf63a4c65c25bbddcb32824d77", "f15383a1130bd2fae1e52a7a15c432269eeb7def555f1f8b9b9a28bd9611362c").
 					WillReturnRows(
 						sqlmock.NewRows([]string{"client_id", "owner_id"}).
 							AddRow("abcdefgh", "owner"),
@@ -1284,7 +1284,7 @@ func TestHandlers_Requiring_Signature(t *testing.T) {
 				aa := sqlmock.AnyArg()
 
 				mock.ExpectExec(`UPDATE "marketplace_share_info"`).
-					WithArgs("regenkey", "kkk", false, aa, "abcdefgh", "f15383a1130bd2fae1e52a7a15c432269eeb7def555f1f8b9b9a28bd9611362c").
+					WithArgs("regenkey", "kkk", false, aa, "da4b54d934890aa415bb043ce1126f2e30a96faf63a4c65c25bbddcb32824d77", "f15383a1130bd2fae1e52a7a15c432269eeb7def555f1f8b9b9a28bd9611362c").
 					WillReturnResult(sqlmock.NewResult(0, 1))
 			},
 			wantCode: http.StatusOK,
@@ -1363,7 +1363,7 @@ func TestHandlers_Requiring_Signature(t *testing.T) {
 					)
 
 				mock.ExpectExec(regexp.QuoteMeta(`UPDATE "marketplace_share_info"`)).
-					WithArgs(true, "abcdefgh", filePathHash).
+					WithArgs(true, "da4b54d934890aa415bb043ce1126f2e30a96faf63a4c65c25bbddcb32824d77", filePathHash).
 					WillReturnResult(sqlmock.NewResult(0, 1))
 
 			},
@@ -1443,7 +1443,7 @@ func TestHandlers_Requiring_Signature(t *testing.T) {
 					)
 
 				mock.ExpectExec(regexp.QuoteMeta(`UPDATE "marketplace_share_info"`)).
-					WithArgs(true, "abcdefgh", filePathHash).
+					WithArgs(true, "da4b54d934890aa415bb043ce1126f2e30a96faf63a4c65c25bbddcb32824d77", filePathHash).
 					WillReturnResult(sqlmock.NewResult(0, 0))
 
 			},

--- a/code/go/0chain.net/blobbercore/handler/handler_test.go
+++ b/code/go/0chain.net/blobbercore/handler/handler_test.go
@@ -1125,7 +1125,7 @@ func TestHandlers_Requiring_Signature(t *testing.T) {
 					body := bytes.NewBuffer(nil)
 					formWriter := multipart.NewWriter(body)
 					shareClientEncryptionPublicKey := "kkk"
-					shareClientID := "abcdefgh"
+					shareClientID := "da4b54d934890aa415bb043ce1126f2e30a96faf63a4c65c25bbddcb32824d77"
 					require.NoError(t, formWriter.WriteField("encryption_public_key", shareClientEncryptionPublicKey))
 					remotePath := "/file.txt"
 					filePathHash := "f15383a1130bd2fae1e52a7a15c432269eeb7def555f1f8b9b9a28bd9611362c"
@@ -1213,7 +1213,7 @@ func TestHandlers_Requiring_Signature(t *testing.T) {
 					body := bytes.NewBuffer(nil)
 					formWriter := multipart.NewWriter(body)
 					shareClientEncryptionPublicKey := "kkk"
-					shareClientID := "abcdefgh"
+					shareClientID := "da4b54d934890aa415bb043ce1126f2e30a96faf63a4c65c25bbddcb32824d77"
 					require.NoError(t, formWriter.WriteField("encryption_public_key", shareClientEncryptionPublicKey))
 					remotePath := "/file.txt"
 					filePathHash := "f15383a1130bd2fae1e52a7a15c432269eeb7def555f1f8b9b9a28bd9611362c"
@@ -1303,7 +1303,7 @@ func TestHandlers_Requiring_Signature(t *testing.T) {
 
 					body := bytes.NewBuffer(nil)
 					formWriter := multipart.NewWriter(body)
-					shareClientID := "abcdefgh"
+					shareClientID := "da4b54d934890aa415bb043ce1126f2e30a96faf63a4c65c25bbddcb32824d77"
 					remotePath := "/file.txt"
 
 					require.NoError(t, formWriter.WriteField("refereeClientID", shareClientID))
@@ -1383,7 +1383,7 @@ func TestHandlers_Requiring_Signature(t *testing.T) {
 
 					body := bytes.NewBuffer(nil)
 					formWriter := multipart.NewWriter(body)
-					shareClientID := "abcdefgh"
+					shareClientID := "da4b54d934890aa415bb043ce1126f2e30a96faf63a4c65c25bbddcb32824d77"
 					remotePath := "/file.txt"
 
 					require.NoError(t, formWriter.WriteField("refereeClientID", shareClientID))


### PR DESCRIPTION
Related to https://github.com/0chain/blobber/issues/388

The error was due to wrong clientID passed - it was allowing to generate authticket and then send it to blobber, hence blobber failed with sql error, as there are limit for field size