### PR TITLE
:bug: Root folder sharing not allowing to dig inside 2nd layer subfolders

### DIFF
--- a/code/go/0chain.net/blobbercore/handler/handler_test.go
+++ b/code/go/0chain.net/blobbercore/handler/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -272,7 +273,11 @@ func GetAuthTicketForEncryptedFile(allocationID string, remotePath string, fileH
 	at.ClientID = clientID
 	at.FileName = remotePath
 	at.FilePathHash = fileHash
-	at.RefType = fileref.FILE
+	if strings.HasSuffix(remotePath, "/") {
+		at.RefType = fileref.DIRECTORY
+	} else {
+		at.RefType = fileref.FILE
+	}
 	timestamp := int64(common.Now())
 	at.Expiration = timestamp + 7776000
 	at.Timestamp = timestamp
@@ -1897,6 +1902,421 @@ func TestHandlers_Requiring_Signature(t *testing.T) {
 			},
 			wantCode: http.StatusOK,
 			wantBody: "",
+		},
+		{
+			name: "DownloadFile_Encrypted_InSharedFolder_Permission_Allowed_shared_File",
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					handlerName := handlers["/v1/file/download/{allocation}"]
+					url, err := router.Get(handlerName).URL("allocation", alloc.Tx)
+					if err != nil {
+						t.Fatal()
+					}
+
+					body := bytes.NewBuffer(nil)
+					formWriter := multipart.NewWriter(body)
+
+					remotePath := "/"
+					pathHash := fileref.GetReferenceLookup(alloc.Tx, remotePath)
+
+					filePathHash := fileref.GetReferenceLookup(alloc.Tx, "/file.txt")
+					require.NoError(t, formWriter.WriteField("path_hash", filePathHash))
+
+					require.NoError(t, formWriter.WriteField("block_num", fmt.Sprintf("%d", 1)))
+					authTicket, err := GetAuthTicketForEncryptedFile(alloc.ID, remotePath, pathHash, client.GetClientID(), sch.GetPublicKey())
+					if err != nil {
+						t.Fatal(err)
+					}
+					require.NoError(t, formWriter.WriteField("auth_token", authTicket))
+					rm := &marker.ReadMarker{}
+					rm.ClientID = client.GetClientID()
+					rm.ClientPublicKey = client.GetClientPublicKey()
+					rm.BlobberID = ""
+					rm.AllocationID = alloc.ID
+					rm.ReadCounter = 1
+					rm.OwnerID = client.GetClientID()
+					err = rm.Sign()
+					if err != nil {
+						t.Fatal(err)
+					}
+					rmData, err := json.Marshal(rm)
+					require.NoError(t, err)
+					require.NoError(t, formWriter.WriteField("read_marker", string(rmData)))
+					if err := formWriter.Close(); err != nil {
+						t.Fatal(err)
+					}
+					r, err := http.NewRequest(http.MethodPost, url.String(), body)
+					r.Header.Add("Content-Type", formWriter.FormDataContentType())
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					hash := encryption.Hash(alloc.Tx)
+					sign, err := sch.Sign(hash)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					r.Header.Set("Content-Type", formWriter.FormDataContentType())
+					r.Header.Set(common.ClientSignatureHeader, sign)
+					r.Header.Set(common.ClientHeader, alloc.OwnerID)
+					r.Header.Set(common.ClientKeyHeader, alloc.OwnerPublicKey)
+
+					return r
+				}(),
+			},
+			alloc: alloc,
+			begin: func() {
+				dataToEncrypt := "data_to_encrypt"
+				encMsg, err := encscheme.Encrypt([]byte(dataToEncrypt))
+				if err != nil {
+					t.Fatal(err)
+				}
+				header := make([]byte, 2*1024)
+				copy(header[:], encMsg.MessageChecksum+","+encMsg.OverallChecksum)
+				data := append(header, encMsg.EncryptedData...)
+				setMockFileBlock(data)
+			},
+			end: func() {
+				resetMockFileBlock()
+			},
+			setupDbMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "allocations" WHERE`)).
+					WithArgs(alloc.Tx).
+					WillReturnRows(
+						sqlmock.NewRows(
+							[]string{
+								"id", "tx", "expiration_date", "owner_public_key", "owner_id", "blobber_size",
+							},
+						).
+							AddRow(
+								alloc.ID, alloc.Tx, alloc.Expiration, alloc.OwnerPublicKey, alloc.OwnerID, int64(1<<30),
+							),
+					)
+
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "terms" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "allocation_id"}).
+							AddRow(alloc.Terms[0].ID, alloc.Terms[0].AllocationID),
+					)
+
+				filePathHash := fileref.GetReferenceLookup(alloc.Tx, "/file.txt")
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "reference_objects" WHERE`)).
+					WithArgs(alloc.ID, filePathHash).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"path", "type", "path_hash", "lookup_hash", "content_hash", "encrypted_key", "parent_path"}).
+							AddRow("/file.txt", "f", filePathHash, filePathHash, "content_hash", encscheme.GetEncryptedKey(), "/"),
+					)
+
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "collaborators" WHERE`)).
+					WithArgs(client.GetClientID()).
+					WillReturnError(gorm.ErrRecordNotFound)
+
+				rootPathHash := fileref.GetReferenceLookup(alloc.Tx, "/")
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "reference_objects" WHERE`)).
+					WithArgs(alloc.ID, rootPathHash).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"path", "type", "path_hash", "lookup_hash", "content_hash", "encrypted_key", "parent_path"}).
+							AddRow("/", "d", rootPathHash, rootPathHash, "content_hash", "", "."),
+					)
+
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "read_markers" WHERE`)).
+					WithArgs(client.GetClientID()).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"client_id"}).
+							AddRow(client.GetClientID()),
+					)
+
+				aa := sqlmock.AnyArg()
+
+				mock.ExpectExec(`UPDATE "read_markers"`).
+					WithArgs(client.GetClientPublicKey(), alloc.ID, alloc.OwnerID, aa, aa, aa, aa, aa, aa, aa).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+
+				reEncryptionKey, _ := encscheme.GetReGenKey(encscheme.GetEncryptedKey(), "filetype:audio")
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "marketplace_share_info" WHERE`)).
+					WithArgs(client.GetClientID(), rootPathHash).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"re_encryption_key", "client_encryption_public_key"}).
+							AddRow(reEncryptionKey, encscheme.GetEncryptedKey()),
+					)
+
+				mock.ExpectCommit()
+			},
+			wantCode: http.StatusOK,
+			wantBody: "",
+		},
+		{
+			name: "DownloadFile_Encrypted_InSharedFolderSubdirectory_Permission_Allowed_shared_File",
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					handlerName := handlers["/v1/file/download/{allocation}"]
+					url, err := router.Get(handlerName).URL("allocation", alloc.Tx)
+					if err != nil {
+						t.Fatal()
+					}
+
+					body := bytes.NewBuffer(nil)
+					formWriter := multipart.NewWriter(body)
+
+					remotePath := "/folder1"
+					pathHash := fileref.GetReferenceLookup(alloc.Tx, remotePath)
+
+					filePathHash := fileref.GetReferenceLookup(alloc.Tx, "/folder1/subfolder1/file.txt")
+					require.NoError(t, formWriter.WriteField("path_hash", filePathHash))
+
+					require.NoError(t, formWriter.WriteField("block_num", fmt.Sprintf("%d", 1)))
+					authTicket, err := GetAuthTicketForEncryptedFile(alloc.ID, remotePath, pathHash, client.GetClientID(), sch.GetPublicKey())
+					if err != nil {
+						t.Fatal(err)
+					}
+					require.NoError(t, formWriter.WriteField("auth_token", authTicket))
+					rm := &marker.ReadMarker{}
+					rm.ClientID = client.GetClientID()
+					rm.ClientPublicKey = client.GetClientPublicKey()
+					rm.BlobberID = ""
+					rm.AllocationID = alloc.ID
+					rm.ReadCounter = 1
+					rm.OwnerID = client.GetClientID()
+					err = rm.Sign()
+					if err != nil {
+						t.Fatal(err)
+					}
+					rmData, err := json.Marshal(rm)
+					require.NoError(t, err)
+					require.NoError(t, formWriter.WriteField("read_marker", string(rmData)))
+					if err := formWriter.Close(); err != nil {
+						t.Fatal(err)
+					}
+					r, err := http.NewRequest(http.MethodPost, url.String(), body)
+					r.Header.Add("Content-Type", formWriter.FormDataContentType())
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					hash := encryption.Hash(alloc.Tx)
+					sign, err := sch.Sign(hash)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					r.Header.Set("Content-Type", formWriter.FormDataContentType())
+					r.Header.Set(common.ClientSignatureHeader, sign)
+					r.Header.Set(common.ClientHeader, alloc.OwnerID)
+					r.Header.Set(common.ClientKeyHeader, alloc.OwnerPublicKey)
+
+					return r
+				}(),
+			},
+			alloc: alloc,
+			begin: func() {
+				dataToEncrypt := "data_to_encrypt"
+				encMsg, err := encscheme.Encrypt([]byte(dataToEncrypt))
+				if err != nil {
+					t.Fatal(err)
+				}
+				header := make([]byte, 2*1024)
+				copy(header[:], encMsg.MessageChecksum+","+encMsg.OverallChecksum)
+				data := append(header, encMsg.EncryptedData...)
+				setMockFileBlock(data)
+			},
+			end: func() {
+				resetMockFileBlock()
+			},
+			setupDbMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "allocations" WHERE`)).
+					WithArgs(alloc.Tx).
+					WillReturnRows(
+						sqlmock.NewRows(
+							[]string{
+								"id", "tx", "expiration_date", "owner_public_key", "owner_id", "blobber_size",
+							},
+						).
+							AddRow(
+								alloc.ID, alloc.Tx, alloc.Expiration, alloc.OwnerPublicKey, alloc.OwnerID, int64(1<<30),
+							),
+					)
+
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "terms" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "allocation_id"}).
+							AddRow(alloc.Terms[0].ID, alloc.Terms[0].AllocationID),
+					)
+
+				filePathHash := fileref.GetReferenceLookup(alloc.Tx, "/folder1/subfolder1/file.txt")
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "reference_objects" WHERE`)).
+					WithArgs(alloc.ID, filePathHash).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"path", "type", "path_hash", "lookup_hash", "content_hash", "encrypted_key", "parent_path"}).
+							AddRow("/file.txt", "f", filePathHash, filePathHash, "content_hash", encscheme.GetEncryptedKey(), "/folder1/subfolder1"),
+					)
+
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "collaborators" WHERE`)).
+					WithArgs(client.GetClientID()).
+					WillReturnError(gorm.ErrRecordNotFound)
+
+				rootPathHash := fileref.GetReferenceLookup(alloc.Tx, "/folder1")
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "reference_objects" WHERE`)).
+					WithArgs(alloc.ID, rootPathHash).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"path", "type", "path_hash", "lookup_hash", "content_hash", "encrypted_key", "parent_path"}).
+							AddRow("/folder1", "d", rootPathHash, rootPathHash, "content_hash", "", "."),
+					)
+
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "read_markers" WHERE`)).
+					WithArgs(client.GetClientID()).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"client_id"}).
+							AddRow(client.GetClientID()),
+					)
+
+				aa := sqlmock.AnyArg()
+
+				mock.ExpectExec(`UPDATE "read_markers"`).
+					WithArgs(client.GetClientPublicKey(), alloc.ID, alloc.OwnerID, aa, aa, aa, aa, aa, aa, aa).
+					WillReturnResult(sqlmock.NewResult(0, 0))
+
+				reEncryptionKey, _ := encscheme.GetReGenKey(encscheme.GetEncryptedKey(), "filetype:audio")
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "marketplace_share_info" WHERE`)).
+					WithArgs(client.GetClientID(), rootPathHash).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"re_encryption_key", "client_encryption_public_key"}).
+							AddRow(reEncryptionKey, encscheme.GetEncryptedKey()),
+					)
+
+				mock.ExpectCommit()
+			},
+			wantCode: http.StatusOK,
+			wantBody: "",
+		},
+		{
+			name: "DownloadFile_Encrypted_InSharedFolder_WrongFilePath_Permission_Rejected_shared_File",
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					handlerName := handlers["/v1/file/download/{allocation}"]
+					url, err := router.Get(handlerName).URL("allocation", alloc.Tx)
+					if err != nil {
+						t.Fatal()
+					}
+
+					body := bytes.NewBuffer(nil)
+					formWriter := multipart.NewWriter(body)
+
+					remotePath := "/folder1"
+					pathHash := fileref.GetReferenceLookup(alloc.Tx, remotePath)
+
+					filePathHash := fileref.GetReferenceLookup(alloc.Tx, "/folder2/subfolder1/file.txt")
+					require.NoError(t, formWriter.WriteField("path_hash", filePathHash))
+
+					require.NoError(t, formWriter.WriteField("block_num", fmt.Sprintf("%d", 1)))
+					authTicket, err := GetAuthTicketForEncryptedFile(alloc.ID, remotePath, pathHash, client.GetClientID(), sch.GetPublicKey())
+					if err != nil {
+						t.Fatal(err)
+					}
+					require.NoError(t, formWriter.WriteField("auth_token", authTicket))
+					rm := &marker.ReadMarker{}
+					rm.ClientID = client.GetClientID()
+					rm.ClientPublicKey = client.GetClientPublicKey()
+					rm.BlobberID = ""
+					rm.AllocationID = alloc.ID
+					rm.ReadCounter = 1
+					rm.OwnerID = client.GetClientID()
+					err = rm.Sign()
+					if err != nil {
+						t.Fatal(err)
+					}
+					rmData, err := json.Marshal(rm)
+					require.NoError(t, err)
+					require.NoError(t, formWriter.WriteField("read_marker", string(rmData)))
+					if err := formWriter.Close(); err != nil {
+						t.Fatal(err)
+					}
+					r, err := http.NewRequest(http.MethodPost, url.String(), body)
+					r.Header.Add("Content-Type", formWriter.FormDataContentType())
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					hash := encryption.Hash(alloc.Tx)
+					sign, err := sch.Sign(hash)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					r.Header.Set("Content-Type", formWriter.FormDataContentType())
+					r.Header.Set(common.ClientSignatureHeader, sign)
+					r.Header.Set(common.ClientHeader, alloc.OwnerID)
+					r.Header.Set(common.ClientKeyHeader, alloc.OwnerPublicKey)
+
+					return r
+				}(),
+			},
+			alloc: alloc,
+			begin: func() {
+				dataToEncrypt := "data_to_encrypt"
+				encMsg, err := encscheme.Encrypt([]byte(dataToEncrypt))
+				if err != nil {
+					t.Fatal(err)
+				}
+				header := make([]byte, 2*1024)
+				copy(header[:], encMsg.MessageChecksum+","+encMsg.OverallChecksum)
+				data := append(header, encMsg.EncryptedData...)
+				setMockFileBlock(data)
+			},
+			end: func() {
+				resetMockFileBlock()
+			},
+			setupDbMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "allocations" WHERE`)).
+					WithArgs(alloc.Tx).
+					WillReturnRows(
+						sqlmock.NewRows(
+							[]string{
+								"id", "tx", "expiration_date", "owner_public_key", "owner_id", "blobber_size",
+							},
+						).
+							AddRow(
+								alloc.ID, alloc.Tx, alloc.Expiration, alloc.OwnerPublicKey, alloc.OwnerID, int64(1<<30),
+							),
+					)
+
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "terms" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "allocation_id"}).
+							AddRow(alloc.Terms[0].ID, alloc.Terms[0].AllocationID),
+					)
+
+				filePathHash := fileref.GetReferenceLookup(alloc.Tx, "/folder2/subfolder1/file.txt")
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "reference_objects" WHERE`)).
+					WithArgs(alloc.ID, filePathHash).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"path", "type", "path_hash", "lookup_hash", "content_hash", "encrypted_key", "parent_path"}).
+							AddRow("/file.txt", "f", filePathHash, filePathHash, "content_hash", encscheme.GetEncryptedKey(), "/folder2/subfolder1"),
+					)
+
+				rootPathHash := fileref.GetReferenceLookup(alloc.Tx, "/folder1")
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "reference_objects" WHERE`)).
+					WithArgs(alloc.ID, rootPathHash).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"path", "type", "path_hash", "lookup_hash", "content_hash", "encrypted_key", "parent_path"}).
+							AddRow("/folder1", "d", rootPathHash, rootPathHash, "content_hash", "", "/"),
+					)
+
+			},
+			wantCode: http.StatusBadRequest,
+			wantBody: "{\"code\":\"download_file\",\"error\":\"download_file: cannot verify auth ticket: invalid_parameters: Auth ticket is not valid for the resource being requested\"}\n\n",
 		},
 	}
 	tests := append(positiveTests, negativeTests...)

--- a/code/go/0chain.net/blobbercore/handler/storage_handler.go
+++ b/code/go/0chain.net/blobbercore/handler/storage_handler.go
@@ -79,16 +79,13 @@ func (fsh *StorageHandler) verifyAuthTicket(ctx context.Context, authTokenString
 		}
 
 		authRefPath := authTokenRef.Path
-		if strings.HasPrefix(authRefPath, ".") {
+		if strings.HasPrefix(authRefPath, ".") || authRefPath == "/" {
 			authRefPath = ""
 		}
 
 		if refRequested.ParentPath != authTokenRef.Path && !strings.HasPrefix(parentPath, authRefPath+"/") {
 			return false, common.NewError("invalid_parameters", "Auth ticket is not valid for the resource being requested")
 		}
-		//if refRequested.ParentPath != authTokenRef.Path && !strings.HasPrefix(refRequested.ParentPath, authTokenRef.Path+"/") {
-		//	return false, common.NewError("invalid_parameters", "Auth ticket is not valid for the resource being requested")
-		//}
 	}
 
 	return true, nil

--- a/code/go/0chain.net/blobbercore/handler/storage_handler.go
+++ b/code/go/0chain.net/blobbercore/handler/storage_handler.go
@@ -72,9 +72,23 @@ func (fsh *StorageHandler) verifyAuthTicket(ctx context.Context, authTokenString
 		if err != nil {
 			return false, err
 		}
-		if refRequested.ParentPath != authTokenRef.Path && !strings.HasPrefix(refRequested.ParentPath, authTokenRef.Path+"/") {
+
+		parentPath := refRequested.ParentPath
+		if !strings.HasPrefix(parentPath, "/") {
+			parentPath = "/" + parentPath
+		}
+
+		authRefPath := authTokenRef.Path
+		if strings.HasPrefix(authRefPath, ".") {
+			authRefPath = ""
+		}
+
+		if refRequested.ParentPath != authTokenRef.Path && !strings.HasPrefix(parentPath, authRefPath+"/") {
 			return false, common.NewError("invalid_parameters", "Auth ticket is not valid for the resource being requested")
 		}
+		//if refRequested.ParentPath != authTokenRef.Path && !strings.HasPrefix(refRequested.ParentPath, authTokenRef.Path+"/") {
+		//	return false, common.NewError("invalid_parameters", "Auth ticket is not valid for the resource being requested")
+		//}
 	}
 
 	return true, nil


### PR DESCRIPTION
The issue happens when the user shares the root directory of allocation "/" and then tries to access 2nd and a deeper level of files by auth_ticke, i.e. shared folder "/", access "/text.txt" - OK, access "/sub/text.txt" - FAIL
This branch resolving issue above