### PR TITLE
Fix missing build tag

### DIFF
--- a/dev.local/cli.sh
+++ b/dev.local/cli.sh
@@ -179,7 +179,7 @@ start_blobber () {
 
     echo "[1/3] build blobber..."
     cd ../code/go/0chain.net/blobber   
-    go build -v -tags "bn256 development" -ldflags "-X 0chain.net/core/build.BuildTag=dev" -o $root/data/blobber$i/blobber .
+    go build -v -tags "bn256 development" -ldflags "-X github.com/0chain/blobber/code/go/0chain.net/core/build.BuildTag=dev" -o $root/data/blobber$i/blobber .
 
     echo "[2/3] setup runtime..."
     prepareRuntime;
@@ -206,7 +206,7 @@ start_validator () {
 
     echo "[1/3] build validator..."
     cd ../code/go/0chain.net/validator   
-    go build -v -tags "bn256 development" -gcflags="-N -l" -ldflags "-X 0chain.net/core/build.BuildTag=dev" -o $root/data/blobber$i/validator .
+    go build -v -tags "bn256 development" -gcflags="-N -l" -ldflags "-X github.com/0chain/blobber/code/go/0chain.net/core/build.BuildTag=dev" -o $root/data/blobber$i/validator .
 
     echo "[2/3] setup runtime"
     prepareRuntime;

--- a/docker.aws/build.blobber/Dockerfile
+++ b/docker.aws/build.blobber/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR $SRC_DIR/go/0chain.net/blobber
 ARG image_tag
 ARG go_build_mode
 ARG go_bls_tag
-RUN go build -v -tags ${go_build_mode} -tags ${go_bls_tag} -ldflags "-X 0chain.net/core/build.BuildTag=${image_tag}"
+RUN go build -v -tags ${go_build_mode} -tags ${go_bls_tag} -ldflags "-X github.com/0chain/blobber/code/go/0chain.net/core/build.BuildTag=${image_tag}"
 
 # Copy the build artifact into a minimal runtime image:
 FROM golang:1.17.1-alpine3.14

--- a/docker.aws/build.validator/Dockerfile
+++ b/docker.aws/build.validator/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR $SRC_DIR/go/0chain.net/validator
 ARG image_tag
 ARG go_build_mode
 ARG go_bls_tag
-RUN go build -v -tags ${go_build_mode} -tags ${go_bls_tag} -ldflags "-X 0chain.net/core/build.BuildTag=${image_tag}"
+RUN go build -v -tags ${go_build_mode} -tags ${go_bls_tag} -ldflags "-X github.com/0chain/blobber/code/go/0chain.net/core/build.BuildTag=${image_tag}"
 
 # Copy the build artifact into a minimal runtime image:
 FROM golang:1.17.1-alpine3.14

--- a/docker.local/Dockerfile
+++ b/docker.local/Dockerfile
@@ -36,7 +36,7 @@ WORKDIR $SRC_DIR/code/go/0chain.net/blobber
 
 ARG GIT_COMMIT
 ENV GIT_COMMIT=$GIT_COMMIT
-RUN go build -v -tags "bn256 development" -gcflags "all=-N -l" -ldflags "-X 0chain.net/core/build.BuildTag=$GIT_COMMIT"
+RUN go build -v -tags "bn256 development" -gcflags "all=-N -l" -ldflags "-X github.com/0chain/blobber/code/go/0chain.net/core/build.BuildTag=$GIT_COMMIT"
 
 # Copy the build artifact into a minimal runtime image:
 FROM golang:1.17.1-alpine3.14

--- a/docker.local/Dockerfile.dev
+++ b/docker.local/Dockerfile.dev
@@ -35,7 +35,7 @@ WORKDIR $SRC_DIR/go/0chain.net/blobber
 
 ARG GIT_COMMIT
 ENV GIT_COMMIT=$GIT_COMMIT
-RUN go build -v -tags "bn256 development" -ldflags "-X 0chain.net/core/build.BuildTag=$GIT_COMMIT"
+RUN go build -v -tags "bn256 development" -ldflags "-X github.com/0chain/blobber/code/go/0chain.net/core/build.BuildTag=$GIT_COMMIT"
 
 # Copy the build artifact into a minimal runtime image:
 FROM golang:1.17.1-alpine3.14

--- a/docker.local/IntegrationTestsBlobberDockerfile
+++ b/docker.local/IntegrationTestsBlobberDockerfile
@@ -28,7 +28,7 @@ ADD ./code/go/0chain.net $SRC_DIR/go/0chain.net
 
 WORKDIR $SRC_DIR/go/0chain.net/blobber
 
-RUN go build -v -tags "bn256 development integration_tests" -ldflags "-X 0chain.net/core/build.BuildTag=$GIT_COMMIT"
+RUN go build -v -tags "bn256 development integration_tests" -ldflags "-X github.com/0chain/blobber/code/go/0chain.net/core/build.BuildTag=$GIT_COMMIT"
 
 # Copy the build artifact into a minimal runtime image:
 FROM golang:1.17.1-alpine3.14

--- a/docker.local/ValidatorDockerfile
+++ b/docker.local/ValidatorDockerfile
@@ -34,7 +34,7 @@ ADD . $SRC_DIR
 
 WORKDIR $SRC_DIR/code/go/0chain.net/validator
 
-RUN go build -v -tags "bn256 development" -ldflags "-X 0chain.net/core/build.BuildTag=$GIT_COMMIT"
+RUN go build -v -tags "bn256 development" -ldflags "-X github.com/0chain/blobber/code/go/0chain.net/core/build.BuildTag=$GIT_COMMIT"
 
 # Copy the build artifact into a minimal runtime image:
 FROM golang:1.17.1-alpine3.14

--- a/docker.local/ValidatorDockerfile.dev
+++ b/docker.local/ValidatorDockerfile.dev
@@ -33,7 +33,7 @@ ADD ./blobber/code/go/0chain.net $SRC_DIR/go/0chain.net
 
 WORKDIR $SRC_DIR/go/0chain.net/validator
 
-RUN go build -v -tags "bn256 development" -ldflags "-X 0chain.net/core/build.BuildTag=$GIT_COMMIT"
+RUN go build -v -tags "bn256 development" -ldflags "-X github.com/0chain/blobber/code/go/0chain.net/core/build.BuildTag=$GIT_COMMIT"
 
 # Copy the build artifact into a minimal runtime image:
 FROM golang:1.17.1-alpine3.14

--- a/docker.local/blobber.Dockerfile
+++ b/docker.local/blobber.Dockerfile
@@ -1,7 +1,5 @@
 FROM blobber_base as blobber_build
-
 LABEL zchain="blobber"
-
 
 ENV SRC_DIR=/0chain
 ENV GO111MODULE=on
@@ -12,14 +10,13 @@ ENV GO111MODULE=on
 COPY .  $SRC_DIR
 # COPY ./gosdk  /gosdk
 
-RUN cd $SRC_DIR/ && go mod download 
-
+RUN cd $SRC_DIR/ && go mod download
 
 WORKDIR $SRC_DIR/code/go/0chain.net/blobber
 
 ARG GIT_COMMIT
 ENV GIT_COMMIT=$GIT_COMMIT
-RUN go build -v -tags "bn256 development" -ldflags "-X 0chain.net/core/build.BuildTag=$GIT_COMMIT"
+RUN go build -v -tags "bn256 development" -ldflags "-X github.com/0chain/blobber/code/go/0chain.net/core/build.BuildTag=$GIT_COMMIT"
 
 # Copy the build artifact into a minimal runtime image:
 FROM golang:1.17.1-alpine3.14
@@ -28,8 +25,6 @@ COPY --from=blobber_build  /usr/local/lib/libmcl*.so \
                         /usr/local/lib/libbls*.so \
                         /usr/local/lib/
 
-
 ENV APP_DIR=/blobber
 WORKDIR $APP_DIR
 COPY --from=blobber_build /0chain/code/go/0chain.net/blobber/blobber $APP_DIR/bin/blobber
-

--- a/docker.local/validator.Dockerfile
+++ b/docker.local/validator.Dockerfile
@@ -17,7 +17,7 @@ RUN cd $SRC_DIR/ && go mod download
 
 WORKDIR $SRC_DIR/code/go/0chain.net/validator
 
-RUN go build -v -tags "bn256 development" -ldflags "-X 0chain.net/core/build.BuildTag=$GIT_COMMIT"
+RUN go build -v -tags "bn256 development" -ldflags "-X github.com/0chain/blobber/code/go/0chain.net/core/build.BuildTag=$GIT_COMMIT"
 
 # Copy the build artifact into a minimal runtime image:
 FROM golang:1.17.1-alpine3.14


### PR DESCRIPTION
This PR aims to fix an issue of not having valid build tags with blobber images.
It corresponds to the issue discussed here : https://github.com/0chain/blobber/issues/397