### PR TITLE
Fix/integration tests GitHub

### DIFF
--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -6,6 +6,7 @@ on:
       - staging
     tags: 
       - '*'
+  pull_request:
 
   workflow_dispatch:
 

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -21,9 +21,8 @@ jobs:
     steps:
       - name: Set GITHUB_ENV
         run: |
-          echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
-          echo "GOSDK=$(echo $(dirname $(pwd)))/gosdk" >> $GITHUB_ENV
-          echo "TAG=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//-/g' )" >> $GITHUB_ENV
+          echo "BRANCH=$(echo ${GITHUB_REF##*/})" >> $GITHUB_ENV
+          echo "TAG=$(echo ${GITHUB_REF##*/}) | sed 's/\//-/g' )" >> $GITHUB_ENV
       - name: Clone blobber
         uses: actions/checkout@v1     
   

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,17 +42,18 @@ jobs:
       - name: Clone Blobber
         uses: actions/checkout@v1
 
-      - name: Init Postgres
+      - name: Install Postgres
         run: |
           ./docker.local/bin/blobber.init.setup.sh
           cd docker.local/blobber1
           ../bin/blobber.start_github.sh
           docker ps
-      - name: Run Blobber
-        run: make local-run &
+
 
       - name: Run Tests
         run: |
+          make local-run &
+          sleep 10
           go17=$(which go)
           sudo CGO_ENABLED=1 $go17 test -tags bn256  ./... -args integration
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,14 +48,16 @@ jobs:
           cd docker.local/blobber1
           ../bin/blobber.start_github.sh
           docker ps
-
+      - name: Run Blobber
+        run: |
+          make local-run &
+          sleep 5
 
       - name: Run Tests
         run: |
-          make local-run &
-          sleep 10
           go17=$(which go)
-          sudo CGO_ENABLED=1 $go17 test -tags bn256  ./... -args integration
+          root=$(pwd)
+          sudo CGO_ENABLED=1 root=$root integration=1  $go17 test -tags bn256  ./...
 
   golangci:
     name: lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
       - master
       - staging
     tags:
-      - *
+      - "*"
   pull_request:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,8 @@ on:
       - master
       - staging
     tags:
+      - *
   pull_request:
-
 
 jobs:
   unit_tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,13 @@ jobs:
       - name: Run Tests
         run: |
           make local-run &
-          sleep 15
+          running=0
+          echo "checking blobber server status"
+          if [ $running -eq 0 ]; then
+            echo -e "."
+            curl 127.0.0.1:5051 && $running=1 || sleep 1
+          fi
+
           #sudo make integration-tests 
           go17=$(which go)
           root=$(pwd)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,9 +5,11 @@ on:
     branches:
       - master
       - staging
+  tags:
+      - '*'
   pull_request:
-    paths-ignore:
-      - '**.md'
+      - '*'
+
 
 jobs:
   unit_tests:
@@ -59,7 +61,7 @@ jobs:
           cd docker.local/blobber1
           ../bin/blobber.start_github.sh
           docker ps
-      - name: Wait gPRC Server
+      - name: Wait gPRC Server 
         run: |
           running=0
           if [ $running -eq 0 ]; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           make local-run &
           sleep 5
-          make integration-tests 
+          sudo make integration-tests 
           # go17=$(which go)
           # root=$(pwd)
           # sudo CGO_ENABLED=1 root=$root integration=1  $go17 test -tags bn256  ./...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,16 +48,14 @@ jobs:
           cd docker.local/blobber1
           ../bin/blobber.start_github.sh
           docker ps
-      - name: Run Blobber
+      - name: Run Tests
         run: |
           make local-run &
           sleep 5
-
-      - name: Run Tests
-        run: |
-          go17=$(which go)
-          root=$(pwd)
-          sudo CGO_ENABLED=1 root=$root integration=1  $go17 test -tags bn256  ./...
+          make integration-tests 
+          # go17=$(which go)
+          # root=$(pwd)
+          # sudo CGO_ENABLED=1 root=$root integration=1  $go17 test -tags bn256  ./...
 
   golangci:
     name: lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Run Tests
         run: |
           make local-run &
-          sleep 5
+          sleep 15
           #sudo make integration-tests 
           go17=$(which go)
           root=$(pwd)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,14 +50,17 @@ jobs:
           docker ps
       - name: Run Tests
         run: |
+          make local-build
           make local-run &
-          sleep 20
+          sleep 10
           running=0
           echo "checking blobber server status"
           if [ $running -eq 0 ]; then
             echo -e "."
-            curl 127.0.0.1:5051 && $running=1 || sleep 1
+            curl 127.0.0.1:5051 && $running=1 || sleep 2
           fi
+
+          sleep 3
 
           #sudo make integration-tests 
           go17=$(which go)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
           ../bin/blobber.start_github.sh
           docker ps
       - name: Run Blobber
-        run: make local-run 
+        run: make local-run &
 
       - name: Run Tests
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,15 @@ jobs:
           cd docker.local/blobber1
           ../bin/blobber.start_github.sh
           docker ps
+      - name: Wait gPRC Server
+        run: |
+          running=0
+          if [ $running -eq 0 ]; then
+            echo "checking gPRC server status"
+            curl 127.0.0.1:31501 && $running=1 || sleep 3
+          fi
+
+          echo "gRPC server is running"
 
       - name: Run Tests
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,28 +42,14 @@ jobs:
       - name: Clone Blobber
         uses: actions/checkout@v1
 
-      - name: Build Blobber
-        run: |
-          docker network create --driver=bridge --subnet=198.18.0.0/15 --gateway=198.18.0.255 testnet0
-          ./docker.local/bin/build.base.sh
-          ./docker.local/bin/build.blobber.sh
-
-      - name: Run Blobber on gRPC  
+      - name: Init Postgres
         run: |
           ./docker.local/bin/blobber.init.setup.sh
           cd docker.local/blobber1
           ../bin/blobber.start_github.sh
           docker ps
-      - name: Wait gPRC Server 
-        run: |
-          running=0
-          if [ $running -eq 0 ]; then
-            echo "checking gPRC server status"
-            docker ps
-            docker logs blobber1_blobber_1 | grep "\[10/11\]" && $running=1 || sleep 3
-          fi
-
-          echo "gRPC server is running"
+      - name: Run Blobber
+        run: make local-run 
 
       - name: Run Tests
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,17 +51,16 @@ jobs:
       - name: Run Tests
         run: |
           make local-build
-          make local-run &
-          sleep 10
+          sudo make local-run &
+          sleep 15
           running=0
           echo "checking blobber server status"
           if [ $running -eq 0 ]; then
-            echo -e "."
+            echo "checking blobber server status"
             curl 127.0.0.1:5051 && $running=1 || sleep 2
           fi
 
-          sleep 3
-
+          echo =========================[ run tests ]=========================
           #sudo make integration-tests 
           go17=$(which go)
           root=$(pwd)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   unit_tests:
+    name: "Unit Tests"
     runs-on: [self-hosted, load-test]
     steps:
       - name: Setup go 1.17
@@ -21,20 +22,14 @@ jobs:
       - name: Clone blobber
         uses: actions/checkout@v2
 
-      # - name: Set GITHUB_ENV
-      #   run: |
-      #     echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
-      #     echo "GOSDK=$(echo $(dirname $(pwd)))/gosdk" >> $GITHUB_ENV
-      #     echo "TAG=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//-/g' )" >> $GITHUB_ENV
-         
-  
       - name: Run tests
         run: |
           cd $GITHUB_WORKSPACE/code/go/0chain.net/ 
           CGO_ENABLED=1 go test -tags bn256 -race -coverprofile=coverage.txt -covermode=atomic ./...
 
-
   integration_test:
+    name: "Integration Tests"
+    needs: unit_tests
     runs-on: [ubuntu-20.04]
     timeout-minutes: 40
     steps:
@@ -64,7 +59,8 @@ jobs:
           running=0
           if [ $running -eq 0 ]; then
             echo "checking gPRC server status"
-            curl 127.0.0.1:31501 && $running=1 || sleep 3
+            docker ps
+            docker logs blobber1_blobber_1 | grep "\[10/11\]" && $running=1 || sleep 3
           fi
 
           echo "gRPC server is running"
@@ -72,7 +68,7 @@ jobs:
       - name: Run Tests
         run: |
           go17=$(which go)
-          sudo  CGO_ENABLED=1 $go17 test -tags bn256  ./... -args integration
+          sudo CGO_ENABLED=1 $go17 test -tags bn256  ./... -args integration
 
   golangci:
     name: lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,10 +52,10 @@ jobs:
         run: |
           make local-run &
           sleep 5
-          sudo make integration-tests 
-          # go17=$(which go)
-          # root=$(pwd)
-          # sudo CGO_ENABLED=1 root=$root integration=1  $go17 test -tags bn256  ./...
+          #sudo make integration-tests 
+          go17=$(which go)
+          root=$(pwd)
+          sudo CGO_ENABLED=1 root=$root integration=1 $go17 test -tags bn256  ./...
 
   golangci:
     name: lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,8 @@ on:
     branches:
       - master
       - staging
-  tags:
-      - '*'
+    tags:
   pull_request:
-      - '*'
 
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Run Tests
         run: |
           make local-run &
+          sleep 20
           running=0
           echo "checking blobber server status"
           if [ $running -eq 0 ]; then

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@
 ########################################################
 UNAME_OS := $(shell uname -s)
 UNAME_ARCH := $(shell uname -m)
+ROOT := $(shell pwd)
 
 .PHONY: test
 test:
@@ -23,7 +24,7 @@ lint:
 
 .PHONY: integration-tests
 integration-tests:
-	CGO_ENABLED=1 go test -p 1 -tags bn256  ./... -args integration
+	CGO_ENABLED=1 root=$(ROOT) integration=1   go test -p 1 -tags bn256  ./...
 
 .PHONY: local-init
 local-init:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@
 ########################################################
 ########################################################
 ########################################################
-
+UNAME_OS := $(shell uname -s)
+UNAME_ARCH := $(shell uname -m)
 
 .PHONY: test
 test:
@@ -30,7 +31,11 @@ local-init:
 	mkdir -p ./dev.local/data/blobber 
 	#[ -d ./dev.local/data/blobber/config ] && rm -rf ./dev.local/data/blobber/config
 	cp -r ./config ./dev.local/data/blobber/ 
+ifeq ($(UNAME_OS),Darwin)
 	cd ./dev.local/data/blobber/config/ && find . -name "*.yaml" -exec sed -i '' "s/postgres/127.0.0.1/g" {} \;
+else
+	cd ./dev.local/data/blobber/config/ && sed -i "s/postgres/127.0.0.1/g" ./0chain_blobber.yaml
+endif
 	cd ./dev.local/data/blobber && [ -d files ] || mkdir files 
 	cd ./dev.local/data/blobber && [ -d data ] || mkdir data 
 	cd ./dev.local/data/blobber && [ -d log ] || mkdir log
@@ -99,8 +104,7 @@ BUF_INSTALL_FROM_SOURCE := false
 
 ### Everything below this line is meant to be static, i.e. only adjust the above variables. ###
 
-UNAME_OS := $(shell uname -s)
-UNAME_ARCH := $(shell uname -m)
+
 # Buf will be cached to ~/.cache/buf-example.
 CACHE_BASE := $(HOME)/.cache/$(PROJECT)
 # This allows switching between i.e a Docker container and your local setup without overwriting.

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,8 @@ local-run: local-build
 	--log_dir ./data/blobber/log \
 	--db_dir ./data/blobber/data  \
 	--minio_file ../docker.local/keys_config/minio_config.txt \
-	--config_dir ./data/blobber/config
+	--config_dir ./data/blobber/config \
+	-args integration
     
 
 ########################################################

--- a/Makefile
+++ b/Makefile
@@ -43,14 +43,13 @@ endif
 .PHONY: local-build
 local-build: local-init
 	@echo "build blobber..."
-	cd ./code/go/0chain.net/blobber && CGO_ENABLED=1 go build -v -tags "bn256 development" -ldflags "-X github.com/0chain/blobber/code/go/0chain.net/core/build.BuildTag=dev" -o ../../../../dev.local/data/blobber/blobber .
+	cd ./code/go/0chain.net/blobber && CGO_ENABLED=1 go build -tags "bn256 development" -ldflags "-X github.com/0chain/blobber/code/go/0chain.net/core/build.BuildTag=dev" -o ../../../../dev.local/data/blobber/blobber .
 
 
 .PHONY: local-run
 local-run: local-build
 	@echo "run blobber..."
-
-	cd ./dev.local/ && ./data/blobber/blobber \
+	cd ./dev.local/ && integration=1 ./data/blobber/blobber \
 	--port 5051 \
 	--grpc_port 31501 \
 	--hostname 127.0.0.1 \
@@ -60,8 +59,7 @@ local-run: local-build
 	--log_dir ./data/blobber/log \
 	--db_dir ./data/blobber/data  \
 	--minio_file ../docker.local/keys_config/minio_config.txt \
-	--config_dir ./data/blobber/config \
-	-args integration
+	--config_dir ./data/blobber/config
     
 
 ########################################################

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ integration-tests:
 
 .PHONY: local-init
 local-init:
-	@echo "init blobber"
+	@echo "=========================[ init blobber ]========================="
 	mkdir -p ./dev.local/data/blobber 
 	#[ -d ./dev.local/data/blobber/config ] && rm -rf ./dev.local/data/blobber/config
 	cp -r ./config ./dev.local/data/blobber/ 
@@ -43,13 +43,13 @@ endif
 
 .PHONY: local-build
 local-build: local-init
-	@echo "build blobber..."
+	@echo "=========================[ build blobber ]========================="
 	cd ./code/go/0chain.net/blobber && CGO_ENABLED=1 go build -tags "bn256 development" -ldflags "-X github.com/0chain/blobber/code/go/0chain.net/core/build.BuildTag=dev" -o ../../../../dev.local/data/blobber/blobber .
 
 
 .PHONY: local-run
-local-run: local-build
-	@echo "run blobber..."
+local-run: 
+	@echo "=========================[ run blobber ]========================="
 	cd ./dev.local/ && integration=1 ./data/blobber/blobber \
 	--port 5051 \
 	--grpc_port 31501 \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 
 .PHONY: test
 test:
-	CGO_ENABLED=1 go test -tags bn256  ./...;
+	CGO_ENABLED=1 go test -tags bn256  ./...
 
 .PHONY: lint
 lint:
@@ -22,7 +22,7 @@ lint:
 
 .PHONY: integration-tests
 integration-tests:
-	CGO_ENABLED=1 go test -tags bn256  ./... -args integration;
+	CGO_ENABLED=1 go test -tags bn256  ./... -args integration
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ lint:
 
 .PHONY: integration-tests
 integration-tests:
-	CGO_ENABLED=1 go test -tags bn256  ./... -args integration
+	CGO_ENABLED=1 go test -p 1 -tags bn256  ./... -args integration
 
 
 

--- a/code/go/0chain.net/blobber/datastore.go
+++ b/code/go/0chain.net/blobber/datastore.go
@@ -18,7 +18,7 @@ func setupDatabase() error {
 		}
 
 		if err := datastore.GetStore().Open(); err == nil {
-			if i == 1 { // no more attempts
+			if i == 599 { // no more attempts
 				logging.Logger.Error("Failed to connect to the database. Shutting the server down")
 				return err
 			}

--- a/code/go/0chain.net/blobber/flags.go
+++ b/code/go/0chain.net/blobber/flags.go
@@ -54,15 +54,7 @@ func parseFlags() {
 	if httpPort <= 0 {
 		panic("Please specify --port which is the port on which requests are accepted")
 	}
-
-	args := make(map[string]bool)
-	for _, arg := range os.Args {
-		args[arg] = true
-		if arg == "integration" {
-			isIntegrationTest = true
-		}
-
-	}
+	isIntegrationTest = os.Getenv("integration") == "1"
 
 	fmt.Print("		[OK]\n")
 }

--- a/code/go/0chain.net/blobber/flags.go
+++ b/code/go/0chain.net/blobber/flags.go
@@ -3,19 +3,21 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 )
 
 var (
-	deploymentMode int
-	keysFile       string
-	minioFile      string
-	filesDir       string
-	metadataDB     string
-	logDir         string
-	httpPort       int
-	hostname       string
-	configDir      string
-	grpcPort       int
+	deploymentMode    int
+	keysFile          string
+	minioFile         string
+	filesDir          string
+	metadataDB        string
+	logDir            string
+	httpPort          int
+	hostname          string
+	configDir         string
+	grpcPort          int
+	isIntegrationTest bool
 )
 
 func init() {
@@ -52,5 +54,15 @@ func parseFlags() {
 	if httpPort <= 0 {
 		panic("Please specify --port which is the port on which requests are accepted")
 	}
+
+	args := make(map[string]bool)
+	for _, arg := range os.Args {
+		args[arg] = true
+		if arg == "integration" {
+			isIntegrationTest = true
+		}
+
+	}
+
 	fmt.Print("		[OK]\n")
 }

--- a/code/go/0chain.net/blobber/grpc.go
+++ b/code/go/0chain.net/blobber/grpc.go
@@ -17,11 +17,13 @@ import (
 	"google.golang.org/grpc/reflection"
 )
 
-func startGRPCServer(r mux.Router) {
+func startGRPCServer() {
 
 	common.ConfigRateLimits()
-	initHandlers(&r)
-	grpcServer := handler.NewGRPCServerWithMiddlewares(&r)
+	r := mux.NewRouter()
+	initHandlers(r)
+
+	grpcServer := handler.NewGRPCServerWithMiddlewares(r)
 	reflection.Register(grpcServer)
 
 	if grpcPort <= 0 {

--- a/code/go/0chain.net/blobber/grpc.go
+++ b/code/go/0chain.net/blobber/grpc.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -16,19 +17,16 @@ import (
 	"google.golang.org/grpc/reflection"
 )
 
-func startGRPCServer() {
-	fmt.Println("[10/11] starting grpc server	[OK]")
-
-	r := mux.NewRouter()
+func startGRPCServer(r mux.Router) {
 
 	common.ConfigRateLimits()
-	initHandlers(r)
-	grpcServer := handler.NewGRPCServerWithMiddlewares(r)
+	initHandlers(&r)
+	grpcServer := handler.NewGRPCServerWithMiddlewares(&r)
 	reflection.Register(grpcServer)
 
 	if grpcPort <= 0 {
 		logging.Logger.Error("grpc port missing")
-		return
+		panic(errors.New("grpc port missing"))
 	}
 
 	logging.Logger.Info("started grpc server on to grpc requests on port - " + strconv.Itoa(grpcPort))
@@ -36,6 +34,9 @@ func startGRPCServer() {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%v", grpcPort))
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
+		panic(err)
 	}
-	log.Fatal(grpcServer.Serve(lis))
+
+	fmt.Println("[10/11] starting grpc server	[OK]")
+	go log.Fatal(grpcServer.Serve(lis))
 }

--- a/code/go/0chain.net/blobber/grpc.go
+++ b/code/go/0chain.net/blobber/grpc.go
@@ -40,5 +40,7 @@ func startGRPCServer() {
 	}
 
 	fmt.Println("[10/11] starting grpc server	[OK]")
-	go log.Fatal(grpcServer.Serve(lis))
+	go func() {
+		log.Fatal(grpcServer.Serve(lis))
+	}()
 }

--- a/code/go/0chain.net/blobber/http.go
+++ b/code/go/0chain.net/blobber/http.go
@@ -22,7 +22,7 @@ import (
 
 var startTime time.Time
 
-func startHttpServer(r *mux.Router) {
+func startHttpServer() {
 
 	mode := "main net"
 	if config.Development() {
@@ -38,6 +38,7 @@ func startHttpServer(r *mux.Router) {
 	var server *http.Server
 
 	common.ConfigRateLimits()
+	r := mux.NewRouter()
 	initHandlers(r)
 
 	if config.Development() {

--- a/code/go/0chain.net/blobber/http.go
+++ b/code/go/0chain.net/blobber/http.go
@@ -22,8 +22,7 @@ import (
 
 var startTime time.Time
 
-func startHttpServer() {
-	fmt.Println("[11/11] start http server	[OK]")
+func startHttpServer(r *mux.Router) {
 
 	mode := "main net"
 	if config.Development() {
@@ -37,8 +36,6 @@ func startHttpServer() {
 	//address := publicIP + ":" + portString
 	address := ":" + strconv.Itoa(httpPort)
 	var server *http.Server
-
-	r := mux.NewRouter()
 
 	common.ConfigRateLimits()
 	initHandlers(r)
@@ -65,7 +62,7 @@ func startHttpServer() {
 	handler.HandleShutdown(common.GetRootContext())
 
 	logging.Logger.Info("Ready to listen to the requests")
-
+	fmt.Println("[11/11] start http server	[OK]")
 	startTime = time.Now().UTC()
 
 	log.Fatal(server.ListenAndServe())

--- a/code/go/0chain.net/blobber/main.go
+++ b/code/go/0chain.net/blobber/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/0chain/blobber/code/go/0chain.net/core/logging"
 	"github.com/0chain/blobber/code/go/0chain.net/core/node"
 )
@@ -24,13 +22,9 @@ func main() {
 		panic(err)
 	}
 
-	if !isIntegrationTest {
-		if err := setupServerChain(); err != nil {
-			logging.Logger.Error("Error setting up server chain" + err.Error())
-			panic(err)
-		}
-	} else {
-		fmt.Print("[6/10] setup server chain	[SKIP]\n")
+	if err := setupServerChain(); err != nil {
+		logging.Logger.Error("Error setting up server chain" + err.Error())
+		panic(err)
 	}
 
 	if err := setupDatabase(); err != nil {
@@ -47,11 +41,7 @@ func main() {
 	// only enabled with "// +build integration_tests"
 	initIntegrationsTests(node.Self.ID)
 
-	if !isIntegrationTest {
-		go setupOnChain()
-	} else {
-		fmt.Print("[9/11] connecting to chain	[SKIP]\n")
-	}
+	go setupOnChain()
 
 	startGRPCServer()
 

--- a/code/go/0chain.net/blobber/main.go
+++ b/code/go/0chain.net/blobber/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"github.com/0chain/blobber/code/go/0chain.net/core/logging"
 	"github.com/0chain/blobber/code/go/0chain.net/core/node"
-	"github.com/gorilla/mux"
 )
 
 func main() {
@@ -44,11 +43,8 @@ func main() {
 
 	go setupOnChain()
 
-	r := mux.NewRouter()
+	startGRPCServer()
 
-	// pass Router by copy
-	startGRPCServer(*r)
-	// pass Router by value
-	startHttpServer(r)
+	startHttpServer()
 
 }

--- a/code/go/0chain.net/blobber/main.go
+++ b/code/go/0chain.net/blobber/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	if err := setupServerChain(); err != nil {
 		logging.Logger.Error("Error setting up server chain" + err.Error())
-		panic(err)
+		//panic(err)
 	}
 
 	if err := setupDatabase(); err != nil {

--- a/code/go/0chain.net/blobber/main.go
+++ b/code/go/0chain.net/blobber/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/0chain/blobber/code/go/0chain.net/core/logging"
 	"github.com/0chain/blobber/code/go/0chain.net/core/node"
+	"github.com/gorilla/mux"
 )
 
 func main() {
@@ -43,11 +44,11 @@ func main() {
 
 	go setupOnChain()
 
-	go startGRPCServer()
-	
-	startHttpServer()
+	r := mux.NewRouter()
 
-
-
+	// pass Router by copy
+	startGRPCServer(*r)
+	// pass Router by value
+	startHttpServer(r)
 
 }

--- a/code/go/0chain.net/blobber/main.go
+++ b/code/go/0chain.net/blobber/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/0chain/blobber/code/go/0chain.net/core/logging"
 	"github.com/0chain/blobber/code/go/0chain.net/core/node"
 )
@@ -27,6 +29,8 @@ func main() {
 			logging.Logger.Error("Error setting up server chain" + err.Error())
 			panic(err)
 		}
+	} else {
+		fmt.Print("[6/10] setup server chain	[SKIP]\n")
 	}
 
 	if err := setupDatabase(); err != nil {
@@ -45,6 +49,8 @@ func main() {
 
 	if !isIntegrationTest {
 		go setupOnChain()
+	} else {
+		fmt.Print("[9/11] connecting to chain	[SKIP]\n")
 	}
 
 	startGRPCServer()

--- a/code/go/0chain.net/blobber/main.go
+++ b/code/go/0chain.net/blobber/main.go
@@ -22,9 +22,11 @@ func main() {
 		panic(err)
 	}
 
-	if err := setupServerChain(); err != nil {
-		logging.Logger.Error("Error setting up server chain" + err.Error())
-		//panic(err)
+	if !isIntegrationTest {
+		if err := setupServerChain(); err != nil {
+			logging.Logger.Error("Error setting up server chain" + err.Error())
+			panic(err)
+		}
 	}
 
 	if err := setupDatabase(); err != nil {
@@ -41,7 +43,9 @@ func main() {
 	// only enabled with "// +build integration_tests"
 	initIntegrationsTests(node.Self.ID)
 
-	go setupOnChain()
+	if !isIntegrationTest {
+		go setupOnChain()
+	}
 
 	startGRPCServer()
 

--- a/code/go/0chain.net/blobber/zcn.go
+++ b/code/go/0chain.net/blobber/zcn.go
@@ -15,6 +15,8 @@ import (
 )
 
 func setupOnChain() {
+	//wait http & grpc startup, and go to setup on chain
+	time.Sleep(1 * time.Second)
 	fmt.Println("[9/11] connecting to chain	")
 
 	const ATTEMPT_DELAY = 60 * 1

--- a/code/go/0chain.net/blobber/zcn.go
+++ b/code/go/0chain.net/blobber/zcn.go
@@ -64,13 +64,14 @@ func setupOnChain() {
 		}
 
 	}
+	if !isIntegrationTest {
+		go setupWorkers()
 
-	go setupWorkers()
+		go keepAliveOnChain()
 
-	go keepAliveOnChain()
-
-	if config.Configuration.PriceInUSD {
-		go refreshPriceOnChain()
+		if config.Configuration.PriceInUSD {
+			go refreshPriceOnChain()
+		}
 	}
 }
 

--- a/code/go/0chain.net/blobbercore/handler/download_integration_test.go
+++ b/code/go/0chain.net/blobbercore/handler/download_integration_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
-	blobbergrpc "github.com/0chain/blobber/code/go/0chain.net/blobbercore/blobbergrpc/proto"
 	"io"
 	"os"
-	"strings"
+	"path/filepath"
 	"testing"
 	"time"
+
+	blobbergrpc "github.com/0chain/blobber/code/go/0chain.net/blobbercore/blobbergrpc/proto"
 
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/readmarker"
 	"github.com/0chain/blobber/code/go/0chain.net/core/common"
@@ -21,27 +22,26 @@ func TestBlobberGRPCService_DownloadFile(t *testing.T) {
 	bClient, tdController := setupHandlerIntegrationTests(t)
 	allocationTx := randString(32)
 
-	root, _ := os.Getwd()
-	path := strings.Split(root, `code`)
+	root := os.Getenv("root")
 
-	err := os.MkdirAll(path[0]+`docker.local/blobber1/files/files/exa/mpl/eId/objects/tmp/Mon/Wen`, os.ModePerm)
+	err := os.MkdirAll(filepath.Join(root, `dev.local/data/blobber/files/files/exa/mpl/eId/objects/tmp/Mon/Wen`), os.ModePerm)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		err := os.RemoveAll(path[0] + `docker.local/blobber1/files/files/exa/mpl/eId/objects/tmp/Mon`)
+		err := os.RemoveAll(filepath.Join(root, `dev.local/data/blobber/files/files/exa/mpl/eId/objects/tmp/Mon`))
 		if err != nil {
 			t.Fatal(err)
 		}
 	}()
 
-	f, err := os.Create(path[0] + `docker.local/blobber1/files/files/exa/mpl/eId/objects/tmp/Mon/Wen/MyFile`)
+	f, err := os.Create(filepath.Join(root, `dev.local/data/blobber/files/files/exa/mpl/eId/objects/tmp/Mon/Wen/MyFile`))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer f.Close()
 
-	file, err := os.Open(root + "/helper_integration_test.go")
+	file, err := os.Open(filepath.Join(root, "/code/go/0chain.net/blobbercore/handler/helper_integration_test.go"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/code/go/0chain.net/blobbercore/handler/getallocation_integration_test.go
+++ b/code/go/0chain.net/blobbercore/handler/getallocation_integration_test.go
@@ -26,14 +26,14 @@ func TestGetAllocation_IntegrationTest(t *testing.T) {
 		expectedTx     string
 		expectingError bool
 	}{
-		{
-			name: "Success",
-			input: &blobbergrpc.GetAllocationRequest{
-				Id: "exampleTransaction",
-			},
-			expectedTx:     "exampleTransaction",
-			expectingError: false,
-		},
+		// {
+		// 	name: "Success",
+		// 	input: &blobbergrpc.GetAllocationRequest{
+		// 		Id: "exampleTransaction",
+		// 	},
+		// 	expectedTx:     "exampleTransaction",
+		// 	expectingError: false,
+		// },
 		{
 			name: "UnknownAllocation",
 			input: &blobbergrpc.GetAllocationRequest{

--- a/code/go/0chain.net/blobbercore/handler/getallocation_integration_test.go
+++ b/code/go/0chain.net/blobbercore/handler/getallocation_integration_test.go
@@ -26,14 +26,14 @@ func TestGetAllocation_IntegrationTest(t *testing.T) {
 		expectedTx     string
 		expectingError bool
 	}{
-		// {
-		// 	name: "Success",
-		// 	input: &blobbergrpc.GetAllocationRequest{
-		// 		Id: "exampleTransaction",
-		// 	},
-		// 	expectedTx:     "exampleTransaction",
-		// 	expectingError: false,
-		// },
+		{
+			name: "Success",
+			input: &blobbergrpc.GetAllocationRequest{
+				Id: "exampleTransaction",
+			},
+			expectedTx:     "exampleTransaction",
+			expectingError: false,
+		},
 		{
 			name: "UnknownAllocation",
 			input: &blobbergrpc.GetAllocationRequest{

--- a/code/go/0chain.net/blobbercore/handler/helper_integration_test.go
+++ b/code/go/0chain.net/blobbercore/handler/helper_integration_test.go
@@ -48,7 +48,7 @@ func setupHandlerIntegrationTests(t *testing.T) (blobbergrpc.BlobberServiceClien
 		args[arg] = true
 	}
 	if !args["integration"] {
-		//t.Skip()
+		t.Skip()
 	}
 
 	var conn *grpc.ClientConn

--- a/code/go/0chain.net/blobbercore/handler/helper_integration_test.go
+++ b/code/go/0chain.net/blobbercore/handler/helper_integration_test.go
@@ -48,7 +48,7 @@ func setupHandlerIntegrationTests(t *testing.T) (blobbergrpc.BlobberServiceClien
 		args[arg] = true
 	}
 	if !args["integration"] {
-		t.Skip()
+		//t.Skip()
 	}
 
 	var conn *grpc.ClientConn

--- a/code/go/0chain.net/blobbercore/handler/helper_integration_test.go
+++ b/code/go/0chain.net/blobbercore/handler/helper_integration_test.go
@@ -43,11 +43,13 @@ func randString(n int) string {
 }
 
 func setupHandlerIntegrationTests(t *testing.T) (blobbergrpc.BlobberServiceClient, *TestDataController) {
-	args := make(map[string]bool)
-	for _, arg := range os.Args {
-		args[arg] = true
-	}
-	if !args["integration"] {
+	// args := make(map[string]bool)
+	// for _, arg := range os.Args {
+	// 	args[arg] = true
+	// }
+
+	if os.Getenv("integration") != "1" {
+		//	if !args["integration"] {
 		t.Skip()
 	}
 

--- a/docker.local/b0docker-compose-github.yml
+++ b/docker.local/b0docker-compose-github.yml
@@ -26,26 +26,6 @@ services:
     links:
       - postgres:postgres
 
-  blobber:
-    image: blobber
-    environment:
-      - DOCKER= true
-    volumes:
-      - ../config:/blobber/config
-      - ./blobber${BLOBBER}/files:/blobber/files
-      - ./blobber${BLOBBER}/data:/blobber/data
-      - ./blobber${BLOBBER}/log:/blobber/log
-      - ./keys_config:/blobber/keysconfig
-      - ./blobber${BLOBBER}/data/tmp:/tmp
-    ports:
-      - 505${BLOBBER}:505${BLOBBER}
-      - 3150${BLOBBER}:3150${BLOBBER}
-    command: ./bin/blobber --port 505${BLOBBER} --grpc_port 3150${BLOBBER} --hostname 198.18.0.9${BLOBBER} --deployment_mode 0 --keys_file keysconfig/b0bnode${BLOBBER}_keys.txt --files_dir /blobber/files --log_dir /blobber/log --db_dir /blobber/data --minio_file keysconfig/minio_config.txt
-    networks:
-      default:
-      testnet0:
-        ipv4_address: 198.18.0.9${BLOBBER}
-
 networks:
   default:
     driver: bridge

--- a/docker.local/blobber.Dockerfile
+++ b/docker.local/blobber.Dockerfile
@@ -3,7 +3,7 @@ LABEL zchain="blobber"
 
 ENV SRC_DIR=/0chain
 ENV GO111MODULE=on
-#ENV GOPROXY=https://goproxy.cn,direct 
+ENV GOPROXY=http://10.10.10.100:3080 
 
 # Download the dependencies:
 # Will be cached if we don't change mod/sum files

--- a/docker.local/blobber.Dockerfile
+++ b/docker.local/blobber.Dockerfile
@@ -3,7 +3,7 @@ LABEL zchain="blobber"
 
 ENV SRC_DIR=/0chain
 ENV GO111MODULE=on
-ENV GOPROXY=http://10.10.10.100:3080 
+# ENV GOPROXY=http://10.10.10.100:3080 
 
 # Download the dependencies:
 # Will be cached if we don't change mod/sum files


### PR DESCRIPTION
- run blobber outside docker on integration-tests. and save time to build docker images. It takes only 2-5 minutes now. it was 20-30 minutes.
- add commands `make local-init` `make local-build` and `make local-run` on Makefile for local development and debugging
- fixed some bugs on grpc test code.