### PR TITLE
in case of listing for newallocation

### DIFF
--- a/code/go/0chain.net/blobbercore/handler/storage_handler.go
+++ b/code/go/0chain.net/blobbercore/handler/storage_handler.go
@@ -455,7 +455,15 @@ func (fsh *StorageHandler) ListEntities(ctx context.Context, r *http.Request) (*
 		}
 	}
 
-	dirref, err := reference.GetRefWithChildren(ctx, allocationID, fileref.Path)
+	// when '/' is not available in database we ignore 'record not found' error. which results into nil fileRef
+	// to handle that condition use filePath '/' while file ref is nil and path  is '/'
+	filePath := path
+	if fileref != nil {
+		filePath = fileref.Path
+	} else if path != "/" {
+		return nil, common.NewError("invalid_parameters", "Invalid path: ref not found ")
+	}
+	dirref, err := reference.GetRefWithChildren(ctx, allocationID, filePath)
 	if err != nil {
 		return nil, common.NewError("invalid_parameters", "Invalid path. "+err.Error())
 	}


### PR DESCRIPTION
if we try to get file ref from db for path / it is not available.
in that case we ignore the error which result in nil fileref and nil pointer error.

to resolve that condition in case of nil fileref and path / we can use / directing to get the data and avoid nil pointer issue.

Signed-off-by: Pradip Parmar <pradip@alfa-creator.com>