### PR TITLE
Remove  max_file_size restriction

### DIFF
--- a/code/go/0chain.net/blobber/config.go
+++ b/code/go/0chain.net/blobber/config.go
@@ -51,7 +51,6 @@ func setupConfig() {
 	config.Configuration.MinioUseSSL = viper.GetBool("minio.use_ssl")
 
 	config.Configuration.Capacity = viper.GetInt64("capacity")
-	config.Configuration.MaxFileSize = viper.GetInt64("max_file_size")
 
 	config.Configuration.DBHost = viper.GetString("db.host")
 	config.Configuration.DBName = viper.GetString("db.name")

--- a/code/go/0chain.net/blobbercore/allocation/renamefilechange_test.go
+++ b/code/go/0chain.net/blobbercore/allocation/renamefilechange_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	bconfig "github.com/0chain/blobber/code/go/0chain.net/blobbercore/config"
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/datastore"
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/filestore"
 	"github.com/0chain/blobber/code/go/0chain.net/core/chain"
@@ -110,7 +109,6 @@ func init() {
 	if _, err := filestore.SetupFSStoreI(dir+"/tmp", MockFileBlockGetter{}); err != nil {
 		panic(err)
 	}
-	bconfig.Configuration.MaxFileSize = int64(1 << 30)
 }
 
 func TestBlobberCore_RenameFile(t *testing.T) {

--- a/code/go/0chain.net/blobbercore/config/config.go
+++ b/code/go/0chain.net/blobbercore/config/config.go
@@ -94,7 +94,6 @@ type Config struct {
 	ChallengeMaxRetires           int
 	TempFilesCleanupFreq          int64
 	TempFilesCleanupNumWorkers    int
-	MaxFileSize                   int64
 
 	ColdStorageMinimumFileSize   int64
 	ColdStorageTimeLimitInHours  int64

--- a/code/go/0chain.net/blobbercore/handler/file_command_add.go
+++ b/code/go/0chain.net/blobbercore/handler/file_command_add.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/allocation"
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/blobberhttp"
-	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/config"
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/filestore"
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/reference"
 	"github.com/0chain/blobber/code/go/0chain.net/core/common"
@@ -93,10 +92,6 @@ func (cmd *AddFileCommand) ProcessContent(ctx context.Context, req *http.Request
 	// only update connection size when the chunk is uploaded by first time.
 	if !fileOutputData.ChunkUploaded {
 		allocationSize += fileOutputData.Size
-	}
-
-	if allocationSize > config.Configuration.MaxFileSize {
-		return result, common.NewError("file_size_limit_exceeded", "Size for the given file is larger than the max limit")
 	}
 
 	if allocationObj.BlobberSizeUsed+allocationSize > allocationObj.BlobberSize {

--- a/code/go/0chain.net/blobbercore/handler/file_command_update.go
+++ b/code/go/0chain.net/blobbercore/handler/file_command_update.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/allocation"
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/blobberhttp"
-	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/config"
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/filestore"
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/reference"
 	"github.com/0chain/blobber/code/go/0chain.net/core/common"
@@ -66,11 +65,6 @@ func (cmd *UpdateFileCommand) ProcessContent(ctx context.Context, req *http.Requ
 
 	result.Filename = cmd.fileChanger.Filename
 
-	// rejected it on first chunk if actualsize is greater than max_file_size
-	if config.Configuration.MaxFileSize > 0 && cmd.fileChanger.ActualSize > config.Configuration.MaxFileSize {
-		return result, common.NewError("file_size_limit_exceeded", "Size for the given file is larger than the max limit")
-	}
-
 	origfile, _, err := req.FormFile("uploadFile")
 	if err != nil {
 		return result, common.NewError("invalid_parameters", "Error Reading multi parts for file."+err.Error())
@@ -114,11 +108,6 @@ func (cmd *UpdateFileCommand) ProcessContent(ctx context.Context, req *http.Requ
 
 	if allocationObj.BlobberSizeUsed+(allocationSize-cmd.exisitingFileRef.Size) > allocationObj.BlobberSize {
 		return result, common.NewError("max_allocation_size", "Max size reached for the allocation with this blobber")
-	}
-
-	//max_file_size = 0 means file size is unlimited
-	if fileOutputData.Size > config.Configuration.MaxFileSize && config.Configuration.MaxFileSize > 0 {
-		return result, common.NewError("file_size_limit_exceeded", "Size for the given file is larger than the max limit")
 	}
 
 	cmd.fileChanger.AllocationID = allocationObj.ID

--- a/code/go/0chain.net/blobbercore/handler/handler_test.go
+++ b/code/go/0chain.net/blobbercore/handler/handler_test.go
@@ -29,7 +29,6 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/allocation"
-	bconfig "github.com/0chain/blobber/code/go/0chain.net/blobbercore/config"
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/datastore"
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/filestore"
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/reference"
@@ -85,7 +84,6 @@ func init() {
 	if _, err := filestore.SetupFSStoreI(dir+"/tmp", MockFileBlockGetter{}); err != nil {
 		panic(err)
 	}
-	bconfig.Configuration.MaxFileSize = int64(1 << 30)
 }
 
 func setup(t *testing.T) {

--- a/config/0chain_blobber.yaml
+++ b/config/0chain_blobber.yaml
@@ -37,8 +37,6 @@ challenge_completion_time: 2m # duration to complete a challenge
 read_lock_timeout: 1m
 write_lock_timeout: 1m
 
-max_file_size: 104857600 #10MB,please set it with 0 if file size is unlimited
-
 # update_allocations_interval used to refresh known allocation objects from SC
 update_allocations_interval: 1m
 


### PR DESCRIPTION
https://github.com/0chain/blobber/issues/459

Max file size restriction adds much more complexity and makes less sense to have.
Having said blobber to be able to store infinite size, `max_file_size` is not good to have. Upload will fail if few blobbers reject file because of file size restriction.