### PR TITLE
checkout current branch explicitly on manual system tests

### DIFF
--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -20,8 +20,8 @@ env:
   VALIDATOR_REGISTRY: ${{ secrets.VALIDATOR_REGISTRY }}
 
 jobs:
-  publish_blobber:
-    runs-on: [self-hosted, conductor-test]
+  build_and_publish_blobber:
+    runs-on: [self-hosted, build]
     steps:
       - name: Set GITHUB_ENV
         run: |
@@ -52,8 +52,8 @@ jobs:
           docker tag blobber:latest ${BLOBBER_REGISTRY}:$TAG-$SHORT_SHA
           docker push ${BLOBBER_REGISTRY}:$TAG-$SHORT_SHA  || { sleep 10 && docker push ${BLOBBER_REGISTRY}:$TAG-$SHORT_SHA; }
 
-  publish_validator:
-    runs-on: [self-hosted, conductor-test]
+  build_and_publish_validator:
+    runs-on: [self-hosted, build]
     steps:
       - name: Set GITHUB_ENV
         run: |
@@ -86,7 +86,7 @@ jobs:
 
   system-tests:
     if: github.event_name != 'workflow_dispatch'
-    needs: [publish_blobber, publish_validator]
+    needs: [build_and_publish_blobber, build_and_publish_validator]
     runs-on: [ tests-suite ]
     steps:
       - name: "Get current PR"

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -20,30 +20,6 @@ env:
   VALIDATOR_REGISTRY: ${{ secrets.VALIDATOR_REGISTRY }}
 
 jobs:
-  build_base:
-    runs-on: [self-hosted, build]
-    steps:
-      - name: Set GITHUB_ENV
-        run: |
-          echo "BRANCH=$(echo ${GITHUB_REF##*/})" >> $GITHUB_ENV
-          echo "TAG=$(echo ${GITHUB_REF##*/} | sed 's/\//-/g' )" >> $GITHUB_ENV
-      - name: Clone blobber
-        uses: actions/checkout@v1     
-  
-      - name: Build blobber_base
-        run: ./docker.local/bin/build.base.sh
-
-      - name: Export blobber_base
-        run:  |
-          mkdir -p /tmp/0chain/
-          docker save "blobber_base" > /tmp/0chain/blobber_base.tar
-
-      - name: Upload blobber_base
-        uses: actions/upload-artifact@v2
-        with:
-          name: blobber_base
-          path: /tmp/0chain/blobber_base.tar
-
   publish_blobber:
     needs: build_base
     runs-on: [self-hosted, conductor-test]
@@ -56,15 +32,8 @@ jobs:
       - name: Clone blobber
         uses: actions/checkout@v1
 
-      - name: Download blobber_base
-        uses: actions/download-artifact@v2
-        with:
-          name: blobber_base
-          path: /tmp/0chain
-
-      - name: Load blobber_base
-        run: |
-          docker load --input /tmp/0chain/blobber_base.tar
+      - name: Build blobber_base
+        run: ./docker.local/bin/build.base.sh
 
       - name: Build blobber
         run: ./docker.local/bin/build.blobber.sh
@@ -78,11 +47,11 @@ jobs:
       - name: Push blobber
         run: |
           docker tag blobber:latest ${BLOBBER_REGISTRY}:$TAG
-          docker push ${BLOBBER_REGISTRY}:$TAG
+          docker push ${BLOBBER_REGISTRY}:$TAG || { sleep 10 && docker push ${BLOBBER_REGISTRY}:$TAG; }
 
           SHORT_SHA=$(echo $GITHUB_SHA | head -c 8)
           docker tag blobber:latest ${BLOBBER_REGISTRY}:$TAG-$SHORT_SHA
-          docker push ${BLOBBER_REGISTRY}:$TAG-$SHORT_SHA  
+          docker push ${BLOBBER_REGISTRY}:$TAG-$SHORT_SHA  || { sleep 10 && docker push ${BLOBBER_REGISTRY}:$TAG-$SHORT_SHA; }
 
   publish_validator:
     needs: build_base
@@ -96,15 +65,8 @@ jobs:
       - name: Clone blobber
         uses: actions/checkout@v1
 
-      - name: Download blobber_base
-        uses: actions/download-artifact@v2
-        with:
-          name: blobber_base
-          path: /tmp/0chain
-
-      - name: Load blobber_base
-        run: |
-          docker load --input /tmp/0chain/blobber_base.tar
+      - name: Build blobber_base
+        run: ./docker.local/bin/build.base.sh
 
       - name: Build validator
         run: ./docker.local/bin/build.validator.sh
@@ -118,11 +80,11 @@ jobs:
       - name: Push validator
         run: |
           docker tag validator:latest ${VALIDATOR_REGISTRY}:$TAG
-          docker push ${VALIDATOR_REGISTRY}:$TAG
+          docker push ${VALIDATOR_REGISTRY}:$TAG || { sleep 10 && docker push ${VALIDATOR_REGISTRY}:$TAG; }
 
           SHORT_SHA=$(echo $GITHUB_SHA | head -c 8)
           docker tag validator:latest ${VALIDATOR_REGISTRY}:$TAG-$SHORT_SHA
-          docker push ${VALIDATOR_REGISTRY}:$TAG-$SHORT_SHA
+          docker push ${VALIDATOR_REGISTRY}:$TAG-$SHORT_SHA || { sleep 10 && docker push ${VALIDATOR_REGISTRY}:$TAG-$SHORT_SHA; }
 
   system-tests:
     if: github.event_name != 'workflow_dispatch'

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -44,7 +44,7 @@ jobs:
           name: blobber_base
           path: /tmp/0chain/blobber_base.tar
 
-  build_blobber:
+  publish_blobber:
     needs: build_base
     runs-on: [self-hosted, conductor-test]
     steps:
@@ -55,7 +55,6 @@ jobs:
       
       - name: Clone blobber
         uses: actions/checkout@v1
-
 
       - name: Download blobber_base
         uses: actions/download-artifact@v2
@@ -69,42 +68,13 @@ jobs:
 
       - name: Build blobber
         run: ./docker.local/bin/build.blobber.sh
-      
-      - name: Export blobber
-        run:  |
-          mkdir -p /tmp/0chain/
-          docker save "blobber" > /tmp/0chain/blobber.tar
-
-      - name: Upload blobber
-        uses: actions/upload-artifact@v2
-        with:
-          name: blobber
-          path: /tmp/0chain/blobber.tar
-       
-  publish_blobber:
-    needs: build_blobber
-    runs-on: [self-hosted, conductor-test]
-    steps:
-      - name: Set GITHUB_ENV
-        run: |
-          echo "BRANCH=$(echo ${GITHUB_REF##*/})" >> $GITHUB_ENV
-          echo "TAG=$(echo ${GITHUB_REF##*/} | sed 's/\//-/g' )" >> $GITHUB_ENV
-
-      - name: Download blobber
-        uses: actions/download-artifact@v2
-        with:
-          name: blobber
-          path: /tmp/0chain
-
-      - name: Load blobber
-        run: |
-          docker load --input /tmp/0chain/blobber.tar
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Push blobber
         run: |
           docker tag blobber:latest ${BLOBBER_REGISTRY}:$TAG
@@ -114,9 +84,7 @@ jobs:
           docker tag blobber:latest ${BLOBBER_REGISTRY}:$TAG-$SHORT_SHA
           docker push ${BLOBBER_REGISTRY}:$TAG-$SHORT_SHA  
 
-        
-
-  build_validator:
+  publish_validator:
     needs: build_base
     runs-on: [self-hosted, conductor-test]
     steps:
@@ -128,7 +96,6 @@ jobs:
       - name: Clone blobber
         uses: actions/checkout@v1
 
-
       - name: Download blobber_base
         uses: actions/download-artifact@v2
         with:
@@ -138,47 +105,16 @@ jobs:
       - name: Load blobber_base
         run: |
           docker load --input /tmp/0chain/blobber_base.tar
-          
-        #docker image ls -a
 
       - name: Build validator
         run: ./docker.local/bin/build.validator.sh
-      
-      - name: Export validator
-        run:  |
-          mkdir -p /tmp/0chain/
-          docker save "validator" > /tmp/0chain/validator.tar
-
-      - name: Upload validator
-        uses: actions/upload-artifact@v2
-        with:
-          name: validator
-          path: /tmp/0chain/validator.tar
-       
-  publish_validator:
-    needs: build_validator
-    runs-on: [self-hosted, conductor-test]
-    steps:
-      - name: Set GITHUB_ENV
-        run: |
-          echo "BRANCH=$(echo ${GITHUB_REF##*/})" >> $GITHUB_ENV
-          echo "TAG=$(echo ${GITHUB_REF##*/} | sed 's/\//-/g' )" >> $GITHUB_ENV
-    
-      - name: Download validator
-        uses: actions/download-artifact@v2
-        with:
-          name: validator
-          path: /tmp/0chain
-
-      - name: Load validator
-        run: |
-          docker load --input /tmp/0chain/validator.tar
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Push validator
         run: |
           docker tag validator:latest ${VALIDATOR_REGISTRY}:$TAG

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -21,7 +21,6 @@ env:
 
 jobs:
   publish_blobber:
-    needs: build_base
     runs-on: [self-hosted, conductor-test]
     steps:
       - name: Set GITHUB_ENV
@@ -54,7 +53,6 @@ jobs:
           docker push ${BLOBBER_REGISTRY}:$TAG-$SHORT_SHA  || { sleep 10 && docker push ${BLOBBER_REGISTRY}:$TAG-$SHORT_SHA; }
 
   publish_validator:
-    needs: build_base
     runs-on: [self-hosted, conductor-test]
     steps:
       - name: Set GITHUB_ENV

--- a/.github/workflows/system_tests.yml
+++ b/.github/workflows/system_tests.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
 
     - uses: actions/checkout@v2
-        
+
     - name: "Get current PR"
       uses: jwalton/gh-find-current-pr@v1
       id: findPr


### PR DESCRIPTION
Existing workflow:
- built blobber base once then uploaded it 
- subsequent stages would download it 
- built blobber and validator then uploaded them
- subsequent stages would download and publish them

The uploading and downloading added minutes to the build time and was flaky when runners were rotated.
Amalgamated all of these stages into 2 - one for blobber and another for validator 

The result is some duplication (both build blobber base) but they now run much faster

Tasks to complete before merging PR:
- [x]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/blobber/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [x]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a branch at [0chain/system_test](https://github.com/0chain/system_test)