### PR TITLE
fix(init): try ping postgres to check if it is ready

### DIFF
--- a/code/go/0chain.net/blobbercore/datastore/postgres.go
+++ b/code/go/0chain.net/blobbercore/datastore/postgres.go
@@ -28,7 +28,6 @@ func (store *postgresStore) Open() error {
 		config.Configuration.DBPassword)), &gorm.Config{
 		SkipDefaultTransaction: true, // https://gorm.io/docs/performance.html#Disable-Default-Transaction
 		PrepareStmt:            true, //https://gorm.io/docs/performance.html#Caches-Prepared-Statement
-		DisableAutomaticPing:   false,
 	})
 	if err != nil {
 		return common.NewErrorf("db_open_error", "Error opening the DB connection: %v", err)


### PR DESCRIPTION
### Changes


### Fixes
- add ping to check if postgres is ready. Because only tcp+port is checked on `gorm.Open`.  it is considered as ok if postgres is ready, but database is not initialized or login/password is incorrect. see detail bug on https://0chain.slack.com/archives/C02AV6MKT36/p1647005595089089?thread_ts=1646996040.723439&cid=C02AV6MKT36 . so the old code is not enough good to check it.


### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/blobber/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):

