### PR TITLE
Skip gorm inserting values to sequence field

### DIFF
--- a/code/go/0chain.net/blobbercore/challenge/entity.go
+++ b/code/go/0chain.net/blobbercore/challenge/entity.go
@@ -80,7 +80,7 @@ type ChallengeEntity struct {
 	ValidationTickets       []*ValidationTicket   `gorm:"-" json:"validation_tickets"`
 	ObjectPathString        datatypes.JSON        `gorm:"column:object_path" json:"-"`
 	ObjectPath              *reference.ObjectPath `gorm:"-" json:"object_path"`
-	Sequence                int64                 `gorm:"column:sequence;unique;type:bigserial"`
+	Sequence                int64                 `gorm:"column:sequence;unique;type:bigserial;<-:false"`
 	Created                 common.Timestamp      `gorm:"-" json:"created"`
 
 	CreatedAt time.Time `gorm:"created_at;type:timestamp without time zone;not null;default:now()"`


### PR DESCRIPTION
### Fixes
Sequence field is auto-incrementing and unique sequence of a table.
Gorm was trying to put 0 value in each insert. 
Fixed by skipping sequence field in gorm's insert sql statement


### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/blobber/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- 0chain:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
