### PR TITLE
Add `on_chain` field on `/file/stats/<alloc>` endpoint response

### DIFF
--- a/code/go/0chain.net/blobbercore/handler/storage_handler.go
+++ b/code/go/0chain.net/blobbercore/handler/storage_handler.go
@@ -393,6 +393,7 @@ func (fsh *StorageHandler) GetFileStats(ctx context.Context, r *http.Request) (i
 	wm, _ := writemarker.GetWriteMarkerEntity(ctx, fileref.WriteMarker)
 	if wm != nil && fileStats != nil {
 		fileStats.WriteMarkerRedeemTxn = wm.CloseTxnID
+		fileStats.OnChain = wm.OnChain()
 	}
 	var statsMap map[string]interface{}
 	statsBytes, _ := json.Marshal(fileStats)

--- a/code/go/0chain.net/blobbercore/stats/filestats.go
+++ b/code/go/0chain.net/blobbercore/stats/filestats.go
@@ -19,6 +19,7 @@ type FileStats struct {
 	FailedChallenges         int64         `gorm:"column:num_of_failed_challenges" json:"num_of_failed_challenges"`
 	LastChallengeResponseTxn string        `gorm:"column:last_challenge_txn;size:64" json:"last_challenge_txn"`
 	WriteMarkerRedeemTxn     string        `gorm:"-" json:"write_marker_txn"`
+	OnChain                  bool          `gorm:"-" json:"on_chain"`
 	datastore.ModelWithTS
 }
 

--- a/code/go/0chain.net/blobbercore/writemarker/entity.go
+++ b/code/go/0chain.net/blobbercore/writemarker/entity.go
@@ -106,6 +106,10 @@ func (wm *WriteMarkerEntity) UpdateStatus(ctx context.Context, status WriteMarke
 	return
 }
 
+func (wm *WriteMarkerEntity) OnChain() bool {
+	return wm.Status == Committed
+}
+
 // GetWriteMarkerEntity get WriteMarkerEntity from postgres
 func GetWriteMarkerEntity(ctx context.Context, allocation_root string) (*WriteMarkerEntity, error) {
 	db := datastore.GetStore().GetTransaction(ctx)

--- a/code/go/0chain.net/blobbercore/writemarker/entity_test.go
+++ b/code/go/0chain.net/blobbercore/writemarker/entity_test.go
@@ -1,0 +1,13 @@
+package writemarker
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestWriteMarkerEntity_OnChain(t *testing.T) {
+	assert.False(t, (&WriteMarkerEntity{Status: Accepted}).OnChain())
+	assert.False(t, (&WriteMarkerEntity{Status: Failed}).OnChain())
+	assert.True(t, (&WriteMarkerEntity{Status: Committed}).OnChain())
+	assert.False(t, (&WriteMarkerEntity{}).OnChain()) // unspecified
+}


### PR DESCRIPTION
### Changes

Add `on_chain` field on `/file/stats/<alloc>` endpoint response

### Fixes
Fixes https://github.com/0chain/blobber/issues/107


### Tests
Tasks to complete before merging PR:
- [x]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/blobber/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- 0chain:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
