### PR TITLE
Delete thumbnail even if file is not to be deleted

### DIFF
--- a/code/go/0chain.net/blobbercore/filestore/storage.go
+++ b/code/go/0chain.net/blobbercore/filestore/storage.go
@@ -77,6 +77,8 @@ func (fs *FileStore) WriteFile(allocID, conID string, fileData *FileInputData, i
 	if err != nil {
 		return nil, common.NewError("file_open_error", err.Error())
 	}
+	defer f.Close()
+
 	_, err = f.Seek(fileData.UploadOffset, io.SeekStart)
 	if err != nil {
 		return nil, common.NewError("file_seek_error", err.Error())


### PR DESCRIPTION
### Fixes
Even if there are content sharing `refs`, they are not supposed to share `thumbnail`. So if delete operation is called, thumbnail should be deleted regardless
