### PR TITLE
fix(devops): kill blobber grpc process if it exists

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,9 +92,8 @@ jobs:
           echo ===============[  kill blobber instance  ]====================
           sudo apt-get update -y
           sudo apt-get install lsof procps -y
-
-
-          sudo lsof -i tcp:35051 
+        
+          sudo lsof -i tcp:35051 2> /dev/null
           #n=$(sudo lsof -i tcp:35051 | grep -v PID | wc -l)
           #[ $n -gt 0 ] && sudo kill -9 $(lsof -i tcp:35051 | awk '{print $2}' | grep -v PID)
           sudo pkill -9 blobber 2> /dev/null && echo "killed blobber" || echo "no blobber is running"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,6 +90,7 @@ jobs:
       - name: Run Tests
         run: |
           echo "kill previous blobber instance if it exists"
+          sudo apt-get upgrade -y
           sudo apt-get install psmisc -y
           sudo fuser 31501/tcp
           sudo fuser -k 31501/tcp

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,7 +93,7 @@ jobs:
           sudo apt-get update -y
           sudo apt autoremove
           sudo apt-get install lsof -y
-          sudo lsof -i:31501 && sudo lsof -i i:31501 | awk '/31501/{print $2}' | sudo xargs kill
+          sudo lsof -i tcp:31501 && sudo lsof -i tcp:31501 | | awk '{print $2}' | grep -v PID | sudo xargs kill
 
           make local-build
           sudo make local-run &

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,26 +89,26 @@ jobs:
           docker ps
       - name: Run Tests
         run: |
-          echo "kill previous blobber instance if it exists"
+          echo ===============[  kill blobber instance  ]====================
           sudo apt-get update -y
-          sudo apt-get install psmisc -y
-          sudo fuser 31501/tcp
-          sudo fuser -k 31501/tcp
-          sudo fuser 5051/tcp
-          sudo fuser -k 5051/tcp
+          sudo apt-get install psmisc lsof -y
+          #sudo fuser 31501/tcp
+          #sudo fuser -k 31501/tcp
+          #sudo fuser 5051/tcp
+          #sudo fuser -k 5051/tcp
 
-          echo "run blobber instance"
+          echo ===============[   run blobber instance  ]====================
           make local-build
           sudo make local-run &
           sleep 15
           running=0
-          echo "checking blobber server status"
+          echo ===============[ checking blobber status ]====================
           if [ $running -eq 0 ]; then
-            echo "checking blobber server status"
+            echo "checking blobber status"
             curl 127.0.0.1:5051 && $running=1 || sleep 2
           fi
 
-          echo =========================[ run tests ]=========================
+          echo ===============[        run tests        ]====================
           #sudo make integration-tests 
           go=$(which go)
           root=$(pwd)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,7 +97,7 @@ jobs:
           sudo lsof -i tcp:31501 
           #n=$(sudo lsof -i tcp:31501 | grep -v PID | wc -l)
           #[ $n -gt 0 ] && sudo kill -9 $(lsof -i tcp:31501 | awk '{print $2}' | grep -v PID)
-          sudo pkill -9 blobber
+          sudo pkill -9 blobber || echo "no blobber instance"
 
           make local-build
           sudo make local-run &

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,10 +91,13 @@ jobs:
         run: |
           echo ===============[  kill blobber instance  ]====================
           sudo apt-get update -y
-          sudo apt-get install lsof -y
+          sudo apt-get install lsof procps -y
 
-          sudo n=$(lsof -i tcp:31501 | grep -v PID | wc -l)
-          [ $n -gt 0 ] && sudo kill -9 $(sudo lsof -i tcp:31501 | awk '{print $2}' | grep -v PID)
+
+          lsof -i tcp:31501 
+          #sudo n=$(lsof -i tcp:31501 | grep -v PID | wc -l)
+          #[ $n -gt 0 ] && sudo kill -9 $(sudo lsof -i tcp:31501 | awk '{print $2}' | grep -v PID)
+          sudo pkill -9 blobber
 
           make local-build
           sudo make local-run &
@@ -112,4 +115,4 @@ jobs:
           root=$(pwd)
           sudo CGO_ENABLED=1 root=$root integration=1 $go test -tags bn256 -tags=integration  ./...
 
-          sudo kill -9 $(sudo lsof -i tcp:31501 | awk '{print $2}' | grep -v PID)
+          sudo pkill -9 blobber

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,17 +92,8 @@ jobs:
           echo ===============[  kill blobber instance  ]====================
           sudo apt-get update -y
           sudo apt autoremove
-          sudo apt-get install psmisc lsof -y
-          #sudo fuser 31501/tcp
-          #sudo fuser -k 31501/tcp
-          #sudo fuser 5051/tcp
-          #sudo fuser -k 5051/tcp
-
-          sudo lsof -i:31501
-          sudo lsof -i tcp:31501 | awk '/31501/{print $2}' | sudo xargs kill
-          echo ""
-          sudo lsof -i:31501
-
+          sudo apt-get install lsof -y
+          sudo lsof -i:31501 && sudo lsof -i i:31501 | awk '/31501/{print $2}' | sudo xargs kill
 
           make local-build
           sudo make local-run &

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,13 +91,12 @@ jobs:
         run: |
           echo ===============[  kill blobber instance  ]====================
           sudo apt-get update -y
-          sudo apt-get install lsof procps -y
+          sudo apt-get install lsof -y
         
           ps aux | grep blobber
-          #sudo lsof -i tcp:35051 2> /dev/null
+    
           n=$(sudo lsof -i tcp:35051 | grep -v PID | wc -l)
-          [ $n -gt 0 ] && sudo kill -9 $(lsof -i tcp:35051 | awk '{print $2}' | grep -v PID) && echo "killed blobber" || echo "no blobber is running"
-          #sudo pkill -9 blobber 2> /dev/null && echo "killed blobber" || echo "no blobber is running"
+          [ $n -gt 0 ] && sudo kill -9 $(lsof -i tcp:35051 | awk '{print $2}' | grep -v PID) && echo "> killed running blobber for integration-tests" || echo "> no blobber is running for integration-tests"
 
           echo ""
           make local-build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,7 +93,8 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install lsof procps -y
         
-          sudo lsof -i tcp:35051 2> /dev/null
+          ps aux | grep blobber
+          #sudo lsof -i tcp:35051 2> /dev/null
           #n=$(sudo lsof -i tcp:35051 | grep -v PID | wc -l)
           #[ $n -gt 0 ] && sudo kill -9 $(lsof -i tcp:35051 | awk '{print $2}' | grep -v PID)
           sudo pkill -9 blobber 2> /dev/null && echo "killed blobber" || echo "no blobber is running"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,7 +89,9 @@ jobs:
           docker ps
       - name: Run Tests
         run: |
-          apt-get install lsof fuser -y
+          apt-get install lsof -y
+          sudo lsof -i tcp:31501 
+          lsof -i tcp:31501 | awk '/31501/{print $2}' | xargs kill
           sudo lsof -i tcp:31501 
           sudo fuser -k 31501/tcp
           # lsof -i tcp:31501 | awk '/31501/{print $2}' | xargs kill

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,9 +94,9 @@ jobs:
           sudo apt-get install lsof procps -y
 
 
-          lsof -i tcp:31501 
-          #sudo n=$(lsof -i tcp:31501 | grep -v PID | wc -l)
-          #[ $n -gt 0 ] && sudo kill -9 $(sudo lsof -i tcp:31501 | awk '{print $2}' | grep -v PID)
+          sudo lsof -i tcp:31501 
+          #n=$(sudo lsof -i tcp:31501 | grep -v PID | wc -l)
+          #[ $n -gt 0 ] && sudo kill -9 $(lsof -i tcp:31501 | awk '{print $2}' | grep -v PID)
           sudo pkill -9 blobber
 
           make local-build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,9 +91,10 @@ jobs:
         run: |
           echo ===============[  kill blobber instance  ]====================
           sudo apt-get update -y
-          sudo apt autoremove -y
           sudo apt-get install lsof -y
-          sudo lsof -i tcp:31501 && sudo lsof -i tcp:31501 | | awk '{print $2}' | grep -v PID | sudo xargs kill
+
+          sudo n=$(lsof -i tcp:31501 | grep -v PID | wc -l)
+          [ $n -gt 0 ] && sudo lsof -i tcp:31501 | awk '{print $2}' | grep -v PID | sudo xargs kill
 
           make local-build
           sudo make local-run &

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,6 +89,7 @@ jobs:
           docker ps
       - name: Run Tests
         run: |
+          sudo kill -9 $(lsof -t -i:31501)
           make local-build
           sudo make local-run &
           sleep 15

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,9 +91,12 @@ jobs:
         run: |
           echo "kill previous blobber instance if it exists"
           sudo apt-get install psmisc -y
-          fuser 31501/tcp
+          sudo fuser 31501/tcp
           sudo fuser -k 31501/tcp
+          sudo fuser 5051/tcp
+          sudo fuser -k 5051/tcp
 
+          echo "run blobber instance"
           make local-build
           sudo make local-run &
           sleep 15

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Run Tests
         run: |
           echo "kill previous blobber instance if it exists"
-          sudo apt-get upgrade -y
+          sudo apt-get update -y
           sudo apt-get install psmisc -y
           sudo fuser 31501/tcp
           sudo fuser -k 31501/tcp

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,6 +90,7 @@ jobs:
       - name: Run Tests
         run: |
           echo "kill previous blobber instance if it exists"
+          sudo apt-get install psmisc -y
           fuser 31501/tcp
           sudo fuser -k 31501/tcp
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,10 +104,11 @@ jobs:
           sleep 15
           running=0
           echo ===============[ checking blobber status ]====================
-          if [ $running -eq 0 ]; then
-            echo "checking blobber status"
-            curl 127.0.0.1:25051 && $running=1 || sleep 2
-          fi
+          for i in {1..10} 
+          do
+            echo "[$i/10] checking blobber status"
+            curl 127.0.0.1:25051 && break || sleep 2
+          done
 
           echo ===============[        run tests        ]====================
           #sudo make integration-tests 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,11 +94,12 @@ jobs:
           sudo apt-get install lsof procps -y
 
 
-          sudo lsof -i tcp:31501 
-          #n=$(sudo lsof -i tcp:31501 | grep -v PID | wc -l)
-          #[ $n -gt 0 ] && sudo kill -9 $(lsof -i tcp:31501 | awk '{print $2}' | grep -v PID)
-          sudo pkill -9 blobber || echo "no blobber instance"
+          sudo lsof -i tcp:35051 
+          #n=$(sudo lsof -i tcp:35051 | grep -v PID | wc -l)
+          #[ $n -gt 0 ] && sudo kill -9 $(lsof -i tcp:35051 | awk '{print $2}' | grep -v PID)
+          sudo pkill -9 blobber 2> /dev/null && echo "killed blobber" || echo "no blobber is running"
 
+          echo ""
           make local-build
           sudo make local-run &
           sleep 15

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,7 +89,7 @@ jobs:
           docker ps
       - name: Run Tests
         run: |
-          sudo kill -9 $(lsof -t -i:31501)
+          pid=$(lsof -t -i:31501) && sudo kill -9 $pid
           make local-build
           sudo make local-run &
           sleep 15

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,6 +89,7 @@ jobs:
           docker ps
       - name: Run Tests
         run: |
+          apt-get install lsof -y
           pid=$(lsof -t -i:31501) && sudo kill -9 $pid
           make local-build
           sudo make local-run &

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,7 @@ jobs:
           sudo apt-get install lsof -y
 
           sudo n=$(lsof -i tcp:31501 | grep -v PID | wc -l)
-          [ $n -gt 0 ] && sudo lsof -i tcp:31501 | awk '{print $2}' | grep -v PID | sudo xargs kill
+          [ $n -gt 0 ] && sudo kill -9 $(sudo lsof -i tcp:31501 | awk '{print $2}' | grep -v PID)
 
           make local-build
           sudo make local-run &
@@ -111,3 +111,5 @@ jobs:
           go=$(which go)
           root=$(pwd)
           sudo CGO_ENABLED=1 root=$root integration=1 $go test -tags bn256 -tags=integration  ./...
+
+          sudo kill -9 $(sudo lsof -i tcp:31501 | awk '{print $2}' | grep -v PID)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,9 +95,9 @@ jobs:
         
           ps aux | grep blobber
           #sudo lsof -i tcp:35051 2> /dev/null
-          #n=$(sudo lsof -i tcp:35051 | grep -v PID | wc -l)
-          #[ $n -gt 0 ] && sudo kill -9 $(lsof -i tcp:35051 | awk '{print $2}' | grep -v PID)
-          sudo pkill -9 blobber 2> /dev/null && echo "killed blobber" || echo "no blobber is running"
+          n=$(sudo lsof -i tcp:35051 | grep -v PID | wc -l)
+          [ $n -gt 0 ] && sudo kill -9 $(lsof -i tcp:35051 | awk '{print $2}' | grep -v PID) && echo "killed blobber" || echo "no blobber is running"
+          #sudo pkill -9 blobber 2> /dev/null && echo "killed blobber" || echo "no blobber is running"
 
           echo ""
           make local-build
@@ -107,7 +107,7 @@ jobs:
           echo ===============[ checking blobber status ]====================
           if [ $running -eq 0 ]; then
             echo "checking blobber status"
-            curl 127.0.0.1:5051 && $running=1 || sleep 2
+            curl 127.0.0.1:25051 && $running=1 || sleep 2
           fi
 
           echo ===============[        run tests        ]====================

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,15 +91,19 @@ jobs:
         run: |
           echo ===============[  kill blobber instance  ]====================
           sudo apt-get update -y
+          sudo apt autoremove
           sudo apt-get install psmisc lsof -y
           #sudo fuser 31501/tcp
           #sudo fuser -k 31501/tcp
           #sudo fuser 5051/tcp
           #sudo fuser -k 5051/tcp
-          sudo lsof -i:5051
+
+          sudo lsof -i:31501
+          sudo lsof -i tcp:31501 | awk '/31501/{print $2}' | sudo xargs kill
+          echo ""
           sudo lsof -i:31501
 
-          echo ===============[   run blobber instance  ]====================
+
           make local-build
           sudo make local-run &
           sleep 15

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,8 +89,11 @@ jobs:
           docker ps
       - name: Run Tests
         run: |
-          apt-get install lsof -y
-          pid=$(lsof -t -i:31501) && sudo kill -9 $pid
+          apt-get install lsof fuser -y
+          sudo lsof -i tcp:31501 
+          sudo fuser -k 31501/tcp
+          # lsof -i tcp:31501 | awk '/31501/{print $2}' | xargs kill
+          # pid=$(lsof -t -i:31501) && sudo kill -9 $pid
           make local-build
           sudo make local-run &
           sleep 15

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,13 +89,10 @@ jobs:
           docker ps
       - name: Run Tests
         run: |
-          apt-get install lsof -y
-          sudo lsof -i tcp:31501 
-          lsof -i tcp:31501 | awk '/31501/{print $2}' | xargs kill
-          sudo lsof -i tcp:31501 
+          echo "kill previous blobber instance if it exists"
+          fuser 31501/tcp
           sudo fuser -k 31501/tcp
-          # lsof -i tcp:31501 | awk '/31501/{print $2}' | xargs kill
-          # pid=$(lsof -t -i:31501) && sudo kill -9 $pid
+
           make local-build
           sudo make local-run &
           sleep 15

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,6 +96,8 @@ jobs:
           #sudo fuser -k 31501/tcp
           #sudo fuser 5051/tcp
           #sudo fuser -k 5051/tcp
+          sudo lsof -i:5051
+          sudo lsof -i:31501
 
           echo ===============[   run blobber instance  ]====================
           make local-build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           echo ===============[  kill blobber instance  ]====================
           sudo apt-get update -y
-          sudo apt autoremove
+          sudo apt autoremove -y
           sudo apt-get install lsof -y
           sudo lsof -i tcp:31501 && sudo lsof -i tcp:31501 | | awk '{print $2}' | grep -v PID | sudo xargs kill
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ local-build: local-init
 local-run: 
 	@echo "=========================[ run blobber ]========================="
 	cd ./dev.local/ && integration=1 ./data/blobber/blobber \
-	--port 5051 \
+	--port 25051 \
 	--grpc_port 35051 \
 	--hostname 127.0.0.1 \
 	--deployment_mode 0 \

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ local-run:
 	@echo "=========================[ run blobber ]========================="
 	cd ./dev.local/ && integration=1 ./data/blobber/blobber \
 	--port 5051 \
-	--grpc_port 31501 \
+	--grpc_port 35051 \
 	--hostname 127.0.0.1 \
 	--deployment_mode 0 \
 	--keys_file ../docker.local/keys_config/b0bnode1_keys.txt  \

--- a/code/go/0chain.net/blobbercore/handler/helper_integration_test.go
+++ b/code/go/0chain.net/blobbercore/handler/helper_integration_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/0chain/gosdk/core/zcncrypto"
 )
 
-const BlobberTestAddr = "127.0.0.1:31501"
+const BlobberTestAddr = "127.0.0.1:35051"
 const RetryAttempts = 8
 const RetryTimeout = 3
 


### PR DESCRIPTION
### Changes
-

### Fixes
- fixed `:31501 : bind: address already in use` on github action `integration_tests`


### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/blobber/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- 
