### PR TITLE
Starred file and dirs (new Ref.Starred column)

### DIFF
--- a/code/go/0chain.net/blobbercore/blobberhttp/response.go
+++ b/code/go/0chain.net/blobbercore/blobberhttp/response.go
@@ -42,6 +42,10 @@ type RefResult struct {
 	LatestWM   *writemarker.WriteMarker  `json:"latest_write_marker"`
 }
 
+type ListStarredRefsResult struct {
+	Refs []reference.PaginatedRef `json:"refs"`
+}
+
 type ObjectPathResult struct {
 	*reference.ObjectPath
 	LatestWM *writemarker.WriteMarker `json:"latest_write_marker"`

--- a/code/go/0chain.net/blobbercore/handler/handler.go
+++ b/code/go/0chain.net/blobbercore/handler/handler.go
@@ -64,6 +64,9 @@ func SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/v1/file/referencepath/{allocation}", common.ToJSONResponse(WithReadOnlyConnection(ReferencePathHandler)))
 	r.HandleFunc("/v1/file/objecttree/{allocation}", common.ToStatusCode(WithStatusReadOnlyConnection(ObjectTreeHandler))).Methods(http.MethodGet, http.MethodOptions)
 	r.HandleFunc("/v1/file/refs/{allocation}", common.ToJSONResponse(WithReadOnlyConnection(RefsHandler))).Methods(http.MethodGet, http.MethodOptions)
+	r.HandleFunc("/v1/file/star/{allocation}", common.ToJSONResponse(WithConnection(RefStarHandler))).Methods(http.MethodOptions, http.MethodPost)
+	r.HandleFunc("/v1/file/starred/{allocation}", common.ToJSONResponse(WithReadOnlyConnection(ListStarredRefsHandler)))
+
 	//admin related
 	r.HandleFunc("/_debug", common.ToJSONResponse(DumpGoRoutines))
 	r.HandleFunc("/_config", common.ToJSONResponse(GetConfig))
@@ -244,7 +247,6 @@ func RefsHandler(ctx context.Context, r *http.Request) (interface{}, error) {
 }
 
 func RenameHandler(ctx context.Context, r *http.Request) (interface{}, error) {
-
 	ctx = setupHandlerContext(ctx, r)
 	response, err := storageHandler.RenameObject(ctx, r)
 	if err != nil {
@@ -289,6 +291,24 @@ func UpdateAttributesHandler(ctx context.Context, r *http.Request) (interface{},
 
 	ctx = setupHandlerContext(ctx, r)
 	response, err := storageHandler.UpdateObjectAttributes(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func RefStarHandler(ctx context.Context, r *http.Request) (interface{}, error) {
+	ctx = setupHandlerContext(ctx, r)
+	response, err := storageHandler.StarOrUnstarRef(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func ListStarredRefsHandler(ctx context.Context, r *http.Request) (interface{}, error) {
+	ctx = setupHandlerContext(ctx, r)
+	response, err := storageHandler.ListStarredRefs(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/code/go/0chain.net/blobbercore/handler/handler_filestar_test.go
+++ b/code/go/0chain.net/blobbercore/handler/handler_filestar_test.go
@@ -1,0 +1,431 @@
+//go:build !integration
+// +build !integration
+
+package handler
+
+import (
+	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/datastore"
+	"github.com/0chain/blobber/code/go/0chain.net/core/common"
+	"github.com/0chain/blobber/code/go/0chain.net/core/encryption"
+	"github.com/0chain/gosdk/core/zcncrypto"
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"testing"
+	"time"
+)
+
+func TestStorageHandler_StarOrUnstarRef(t *testing.T) {
+	sch := zcncrypto.NewSignatureScheme("bls0chain")
+	testWallet, _ := sch.RecoverKeys("expose culture dignity plastic digital couple promote best pool error brush upgrade correct art become lobster nature moment obtain trial multiply arch miss toe")
+
+	alloc := makeTestAllocation(common.Timestamp(time.Now().Add(time.Hour).Unix()))
+	alloc.OwnerPublicKey = testWallet.ClientKey
+	alloc.OwnerID = testWallet.ClientID
+
+	apiURL := "http://localhost/v1/file/star/" + alloc.ID
+	validSign, _ := sch.Sign(encryption.Hash(alloc.Tx))
+
+	for _, tc := range []struct {
+		desc              string
+		request           *http.Request
+		requestHeaders    http.Header
+		requestForm       url.Values
+		wantResStatusCode int
+		wantResBody       string
+		setupDbMock       func(mock sqlmock.Sqlmock)
+	}{
+		// positive tests
+		{
+			desc:              "method is options",
+			request:           mustHttpReq(http.MethodOptions, apiURL, nil),
+			wantResStatusCode: 204,
+		},
+		{
+			desc:              "success",
+			request:           mustHttpReq(http.MethodPost, apiURL, nil),
+			requestHeaders:    headers(common.ClientHeader, alloc.OwnerID, common.ClientSignatureHeader, validSign),
+			requestForm:       formValues("starred", "true", "path_hash", "dummyHash"),
+			wantResStatusCode: 200,
+			wantResBody:       "{\"msg\":\"Updated ref star successfully\"}",
+			setupDbMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "allocations" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "tx", "expiration_date", "owner_public_key", "owner_id"}).
+							AddRow(alloc.ID, alloc.Tx, alloc.Expiration, alloc.OwnerPublicKey, alloc.OwnerID),
+					)
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "terms" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "allocation_id"}).
+							AddRow(alloc.Terms[0].ID, alloc.Terms[0].AllocationID),
+					)
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "reference_objects" WHERE`)).
+					WithArgs(alloc.ID, "dummyHash").
+					WillReturnRows(
+						sqlmock.NewRows([]string{"path"}).
+							AddRow("/"),
+					)
+				mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "reference_objects"`)).
+					WillReturnRows(
+						sqlmock.NewRows([]string{}),
+					)
+				mock.ExpectCommit()
+			},
+		},
+		// negative tests
+		{
+			desc:              "method is not post",
+			request:           mustHttpReq(http.MethodGet, apiURL, nil),
+			wantResStatusCode: 405,
+			wantResBody:       "",
+		},
+		{
+			desc:              "expired allocation",
+			request:           mustHttpReq(http.MethodPost, apiURL, nil),
+			wantResStatusCode: 400,
+			wantResBody:       "{\"code\":\"invalid_parameters\",\"error\":\"invalid_parameters: Invalid allocation id passed.verify_allocation: use of expired allocation\"}",
+			setupDbMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "allocations" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "tx", "expiration_date", "owner_public_key", "owner_id"}).
+							AddRow(alloc.ID, alloc.Tx, common.Timestamp(time.Now().Add(time.Hour*-1).Unix()), alloc.OwnerPublicKey, alloc.OwnerID),
+					)
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "terms" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "allocation_id"}).
+							AddRow(alloc.Terms[0].ID, alloc.Terms[0].AllocationID),
+					)
+			},
+		},
+		{
+			desc:              "not the owner",
+			request:           mustHttpReq(http.MethodPost, apiURL, nil),
+			requestHeaders:    headers(common.ClientHeader, "otherclient"),
+			wantResStatusCode: 400,
+			wantResBody:       "{\"code\":\"invalid_operation\",\"error\":\"invalid_operation: Operation needs to be performed by the owner of the allocation\"}",
+			setupDbMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "allocations" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "tx", "expiration_date", "owner_public_key", "owner_id"}).
+							AddRow(alloc.ID, alloc.Tx, alloc.Expiration, alloc.OwnerPublicKey, alloc.OwnerID),
+					)
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "terms" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "allocation_id"}).
+							AddRow(alloc.Terms[0].ID, alloc.Terms[0].AllocationID),
+					)
+			},
+		},
+		{
+			desc:              "invalid signature",
+			request:           mustHttpReq(http.MethodPost, apiURL, nil),
+			requestHeaders:    headers(common.ClientHeader, alloc.OwnerID, common.ClientSignatureHeader, "badsignature"),
+			wantResStatusCode: 400,
+			wantResBody:       "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}",
+			setupDbMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "allocations" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "tx", "expiration_date", "owner_public_key", "owner_id"}).
+							AddRow(alloc.ID, alloc.Tx, alloc.Expiration, alloc.OwnerPublicKey, alloc.OwnerID),
+					)
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "terms" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "allocation_id"}).
+							AddRow(alloc.Terms[0].ID, alloc.Terms[0].AllocationID),
+					)
+			},
+		},
+		{
+			desc:              "missing starred param",
+			request:           mustHttpReq(http.MethodPost, apiURL, nil),
+			requestHeaders:    headers(common.ClientHeader, alloc.OwnerID, common.ClientSignatureHeader, validSign),
+			requestForm:       formValues(),
+			wantResStatusCode: 400,
+			wantResBody:       "{\"code\":\"invalid_parameters\",\"error\":\"invalid_parameters: Missing starred.\"}",
+			setupDbMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "allocations" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "tx", "expiration_date", "owner_public_key", "owner_id"}).
+							AddRow(alloc.ID, alloc.Tx, alloc.Expiration, alloc.OwnerPublicKey, alloc.OwnerID),
+					)
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "terms" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "allocation_id"}).
+							AddRow(alloc.Terms[0].ID, alloc.Terms[0].AllocationID),
+					)
+			},
+		},
+		{
+			desc:              "invalid starred param",
+			request:           mustHttpReq(http.MethodPost, apiURL, nil),
+			requestHeaders:    headers(common.ClientHeader, alloc.OwnerID, common.ClientSignatureHeader, validSign),
+			requestForm:       formValues("starred", "yes"),
+			wantResStatusCode: 400,
+			wantResBody:       "{\"code\":\"invalid_parameters\",\"error\":\"invalid_parameters: Invalid starred passed.\"}",
+			setupDbMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "allocations" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "tx", "expiration_date", "owner_public_key", "owner_id"}).
+							AddRow(alloc.ID, alloc.Tx, alloc.Expiration, alloc.OwnerPublicKey, alloc.OwnerID),
+					)
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "terms" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "allocation_id"}).
+							AddRow(alloc.Terms[0].ID, alloc.Terms[0].AllocationID),
+					)
+			},
+		},
+		{
+			desc:              "missing path and path_hash param",
+			request:           mustHttpReq(http.MethodPost, apiURL, nil),
+			requestHeaders:    headers(common.ClientHeader, alloc.OwnerID, common.ClientSignatureHeader, validSign),
+			requestForm:       formValues("starred", "true"),
+			wantResStatusCode: 400,
+			wantResBody:       "{\"code\":\"invalid_parameters\",\"error\":\"invalid_parameters: Invalid path\"}",
+			setupDbMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "allocations" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "tx", "expiration_date", "owner_public_key", "owner_id"}).
+							AddRow(alloc.ID, alloc.Tx, alloc.Expiration, alloc.OwnerPublicKey, alloc.OwnerID),
+					)
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "terms" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "allocation_id"}).
+							AddRow(alloc.Terms[0].ID, alloc.Terms[0].AllocationID),
+					)
+			},
+		},
+		{
+			desc:              "pathHash is not valid",
+			request:           mustHttpReq(http.MethodPost, apiURL, nil),
+			requestHeaders:    headers(common.ClientHeader, alloc.OwnerID, common.ClientSignatureHeader, validSign),
+			requestForm:       formValues("starred", "true", "path_hash", "dummyHash"),
+			wantResStatusCode: 400,
+			wantResBody:       "{\"code\":\"invalid_parameters\",\"error\":\"invalid_parameters: Invalid file path. record not found\"}",
+			setupDbMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "allocations" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "tx", "expiration_date", "owner_public_key", "owner_id"}).
+							AddRow(alloc.ID, alloc.Tx, alloc.Expiration, alloc.OwnerPublicKey, alloc.OwnerID),
+					)
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "terms" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "allocation_id"}).
+							AddRow(alloc.Terms[0].ID, alloc.Terms[0].AllocationID),
+					)
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "reference_objects" WHERE`)).
+					WithArgs(alloc.ID, "dummyHash").
+					WillReturnRows(
+						sqlmock.NewRows([]string{"path"}),
+					)
+			},
+		},
+	} {
+		tt := tc
+		t.Run(tt.desc, func(t *testing.T) {
+			mock := datastore.MockTheStore(t)
+			if tt.setupDbMock != nil {
+				tt.setupDbMock(mock)
+			}
+
+			router := mux.NewRouter()
+			SetupHandlers(router)
+
+			res := httptest.NewRecorder()
+			tt.request.Header = tt.requestHeaders
+			tt.request.Form = tt.requestForm
+
+			router.ServeHTTP(res, tt.request)
+
+			assert.Equal(t, tt.wantResStatusCode, res.Code)
+			assert.Contains(t, res.Body.String(), tt.wantResBody)
+		})
+	}
+}
+
+func TestStorageHandler_ListStarredRefs(t *testing.T) {
+	sch := zcncrypto.NewSignatureScheme("bls0chain")
+	testWallet, _ := sch.RecoverKeys("expose culture dignity plastic digital couple promote best pool error brush upgrade correct art become lobster nature moment obtain trial multiply arch miss toe")
+
+	alloc := makeTestAllocation(common.Timestamp(time.Now().Add(time.Hour).Unix()))
+	alloc.OwnerPublicKey = testWallet.ClientKey
+	alloc.OwnerID = testWallet.ClientID
+
+	apiURL := "http://localhost/v1/file/starred/" + alloc.ID
+	validSign, _ := sch.Sign(encryption.Hash(alloc.Tx))
+
+	for _, tc := range []struct {
+		desc              string
+		request           *http.Request
+		requestHeaders    http.Header
+		wantResStatusCode int
+		wantResBody       string
+		setupDbMock       func(mock sqlmock.Sqlmock)
+	}{
+		// positive tests
+		{
+			desc:              "success",
+			request:           mustHttpReq(http.MethodGet, apiURL, nil),
+			requestHeaders:    headers(common.ClientHeader, alloc.OwnerID, common.ClientSignatureHeader, validSign),
+			wantResStatusCode: 200,
+			wantResBody:       "{\"refs\":[{\"path\":\"/\",\"created_at\":\"0001-01-01T00:00:00Z\",\"updated_at\":\"0001-01-01T00:00:00Z\",\"chunk_size\":0},{\"path\":\"/file\",\"created_at\":\"0001-01-01T00:00:00Z\",\"updated_at\":\"0001-01-01T00:00:00Z\",\"chunk_size\":0}]}",
+			setupDbMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "allocations" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "tx", "expiration_date", "owner_public_key", "owner_id"}).
+							AddRow(alloc.ID, alloc.Tx, alloc.Expiration, alloc.OwnerPublicKey, alloc.OwnerID),
+					)
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "terms" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "allocation_id"}).
+							AddRow(alloc.Terms[0].ID, alloc.Terms[0].AllocationID),
+					)
+				mock.ExpectQuery(regexp.QuoteMeta(`FROM "reference_objects" WHERE`)).
+					WithArgs(alloc.ID, true).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"path"}).
+							AddRow("/").
+							AddRow("/file"),
+					)
+			},
+		},
+		// negative tests
+		{
+			desc:              "expired allocation",
+			request:           mustHttpReq(http.MethodPost, apiURL, nil),
+			wantResStatusCode: 400,
+			wantResBody:       "{\"code\":\"invalid_parameters\",\"error\":\"invalid_parameters: Invalid allocation id passed.verify_allocation: use of expired allocation\"}",
+			setupDbMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "allocations" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "tx", "expiration_date", "owner_public_key", "owner_id"}).
+							AddRow(alloc.ID, alloc.Tx, common.Timestamp(time.Now().Add(time.Hour*-1).Unix()), alloc.OwnerPublicKey, alloc.OwnerID),
+					)
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "terms" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "allocation_id"}).
+							AddRow(alloc.Terms[0].ID, alloc.Terms[0].AllocationID),
+					)
+			},
+		},
+		{
+			desc:              "not the owner",
+			request:           mustHttpReq(http.MethodPost, apiURL, nil),
+			requestHeaders:    headers(common.ClientHeader, "otherclient"),
+			wantResStatusCode: 400,
+			wantResBody:       "{\"code\":\"invalid_operation\",\"error\":\"invalid_operation: Operation needs to be performed by the owner of the allocation\"}",
+			setupDbMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "allocations" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "tx", "expiration_date", "owner_public_key", "owner_id"}).
+							AddRow(alloc.ID, alloc.Tx, alloc.Expiration, alloc.OwnerPublicKey, alloc.OwnerID),
+					)
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "terms" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "allocation_id"}).
+							AddRow(alloc.Terms[0].ID, alloc.Terms[0].AllocationID),
+					)
+			},
+		},
+		{
+			desc:              "invalid signature",
+			request:           mustHttpReq(http.MethodPost, apiURL, nil),
+			requestHeaders:    headers(common.ClientHeader, alloc.OwnerID, common.ClientSignatureHeader, "badsignature"),
+			wantResStatusCode: 400,
+			wantResBody:       "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}",
+			setupDbMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "allocations" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "tx", "expiration_date", "owner_public_key", "owner_id"}).
+							AddRow(alloc.ID, alloc.Tx, alloc.Expiration, alloc.OwnerPublicKey, alloc.OwnerID),
+					)
+				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "terms" WHERE`)).
+					WithArgs(alloc.ID).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"id", "allocation_id"}).
+							AddRow(alloc.Terms[0].ID, alloc.Terms[0].AllocationID),
+					)
+			},
+		},
+	} {
+		tt := tc
+		t.Run(tt.desc, func(t *testing.T) {
+			mock := datastore.MockTheStore(t)
+			if tt.setupDbMock != nil {
+				tt.setupDbMock(mock)
+			}
+
+			router := mux.NewRouter()
+			SetupHandlers(router)
+
+			res := httptest.NewRecorder()
+			tt.request.Header = tt.requestHeaders
+
+			router.ServeHTTP(res, tt.request)
+
+			assert.Equal(t, tt.wantResStatusCode, res.Code)
+			assert.Contains(t, res.Body.String(), tt.wantResBody)
+		})
+	}
+}
+
+func headers(keyAndValues ...string) http.Header {
+	h := http.Header{}
+	for i := 0; i+1 < len(keyAndValues); i += 2 {
+		h.Add(keyAndValues[i], keyAndValues[i+1])
+	}
+	return h
+}
+
+func formValues(keyAndValues ...string) url.Values {
+	v := url.Values{}
+	for i := 0; i+1 < len(keyAndValues); i += 2 {
+		v.Add(keyAndValues[i], keyAndValues[i+1])
+	}
+	return v
+}
+
+func mustHttpReq(method string, url string, body io.Reader) *http.Request {
+	req, _ := http.NewRequest(method, url, body)
+	return req
+}

--- a/code/go/0chain.net/blobbercore/handler/handler_filestar_test.go
+++ b/code/go/0chain.net/blobbercore/handler/handler_filestar_test.go
@@ -297,7 +297,7 @@ func TestStorageHandler_ListStarredRefs(t *testing.T) {
 			request:           mustHttpReq(http.MethodGet, apiURL, nil),
 			requestHeaders:    headers(common.ClientHeader, alloc.OwnerID, common.ClientSignatureHeader, validSign),
 			wantResStatusCode: 200,
-			wantResBody:       "{\"refs\":[{\"path\":\"/\",\"created_at\":\"0001-01-01T00:00:00Z\",\"updated_at\":\"0001-01-01T00:00:00Z\",\"chunk_size\":0},{\"path\":\"/file\",\"created_at\":\"0001-01-01T00:00:00Z\",\"updated_at\":\"0001-01-01T00:00:00Z\",\"chunk_size\":0}]}",
+			wantResBody:       "{\"refs\":[",
 			setupDbMock: func(mock sqlmock.Sqlmock) {
 				mock.ExpectBegin()
 				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "allocations" WHERE`)).

--- a/code/go/0chain.net/blobbercore/reference/ref.go
+++ b/code/go/0chain.net/blobbercore/reference/ref.go
@@ -139,7 +139,9 @@ type PaginatedRef struct { //Gorm smart select fields.
 	EncryptedKey        string         `gorm:"column:encrypted_key" json:"encrypted_key,omitempty"`
 	Attributes          datatypes.JSON `gorm:"column:attributes" json:"attributes,omitempty"`
 
-	OnCloud   bool           `gorm:"column:on_cloud" json:"on_cloud,omitempty"`
+	OnCloud bool `gorm:"column:on_cloud" json:"on_cloud,omitempty"`
+	Starred bool `gorm:"column:starred;default:false" filelist:"starred"`
+
 	CreatedAt time.Time      `gorm:"column:created_at" json:"created_at,omitempty"`
 	UpdatedAt time.Time      `gorm:"column:updated_at" json:"updated_at,omitempty"`
 	DeletedAt gorm.DeletedAt `gorm:"column:deleted_at" json:"-"` // soft deletion

--- a/code/go/0chain.net/blobbercore/reference/ref.go
+++ b/code/go/0chain.net/blobbercore/reference/ref.go
@@ -84,6 +84,7 @@ type Ref struct {
 	Children            []*Ref         `gorm:"-"`
 	childrenLoaded      bool
 	OnCloud             bool `gorm:"column:on_cloud;default:false" filelist:"on_cloud"`
+	Starred             bool `gorm:"column:starred;default:false" filelist:"starred"`
 
 	CommitMetaTxns []CommitMetaTxn `gorm:"foreignkey:ref_id" filelist:"commit_meta_txns"`
 	CreatedAt      time.Time       `gorm:"column:created_at;type:timestamp without time zone;not null;default:now()" dirlist:"created_at" filelist:"created_at"`

--- a/code/go/0chain.net/blobbercore/reference/referencepath.go
+++ b/code/go/0chain.net/blobbercore/reference/referencepath.go
@@ -359,6 +359,7 @@ func GetStarredRefs(ctx context.Context, allocationID string) ([]PaginatedRef, e
 
 	err := db.Model(&Ref{}).Where("allocation_id = ?", allocationID).
 		Where("starred = ?", true).
+		Order("path").
 		Find(&refs).Error
 
 	return refs, err

--- a/code/go/0chain.net/blobbercore/reference/referencepath.go
+++ b/code/go/0chain.net/blobbercore/reference/referencepath.go
@@ -351,3 +351,15 @@ func CountRefs(ctx context.Context, allocationID string) (int64, error) {
 
 	return totalRows, err
 }
+
+func GetStarredRefs(ctx context.Context, allocationID string) ([]PaginatedRef, error) {
+	var refs []PaginatedRef
+
+	db := datastore.GetStore().GetDB()
+
+	err := db.Model(&Ref{}).Where("allocation_id = ?", allocationID).
+		Where("starred = ?", true).
+		Find(&refs).Error
+
+	return refs, err
+}


### PR DESCRIPTION
### Changes

New `Ref.Starred` column to indicate whether a directory or a file is starred or favorited.

Two new REST API added to support adding star to a file/dir and to list all starred file/dir
- `POST /v1/file/star/{allocation}` - accepts a boolean param `starred` and `path` or `path_hash`. The `Ref.Starred` of the affected file will be set to value of `starred` param.
- `GET /v1/file/starred/{allocation}` - list all refs with `Ref.Starred = true` on the allocation.

Both APIs can only be called by the allocation owner. Both request must be signed.

### Fixes

Resolves https://github.com/0chain/blobber/issues/700


### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/blobber/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- 0chain:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
