### PR TITLE
Use lock before readmarker is considered ok

### DIFF
--- a/code/go/0chain.net/blobbercore/handler/object_operation_handler.go
+++ b/code/go/0chain.net/blobbercore/handler/object_operation_handler.go
@@ -170,6 +170,15 @@ func (fsh *StorageHandler) DownloadFile(ctx context.Context, r *http.Request) (r
 		return nil, common.NewErrorf("download_file", "invalid allocation id passed: %v", err)
 	}
 
+	key := clientID + ":" + alloc.ID
+	lock, isNewLock := readmarker.ReadmarkerMapLock.GetLock(key)
+	if !isNewLock {
+		return nil, common.NewErrorf("lock_exists", fmt.Sprintf("lock exists for key: %v", key))
+	}
+
+	lock.Lock()
+	defer lock.Unlock()
+
 	dr, err := FromDownloadRequest(allocationTx, r)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Fixes
This PR will try to acquire lock before readmarker is considered alright. Otherwise ReadCounter will be unreliable.


### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/blobber/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- 0chain:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
