### PR TITLE
fix(challenge): load challenges one by one from db to prevent oomkilled

### DIFF
--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   blobber:
-    runs-on: [self-hosted, build]
+    runs-on: [self-hosted, docker-builds]
     steps:
       - name: Set docker image tag 
         run: |
@@ -64,7 +64,7 @@ jobs:
           ./docker.local/bin/build.base.sh && ./docker.local/bin/build.blobber.sh
 
   validator:
-    runs-on: [self-hosted, build]
+    runs-on: [self-hosted, docker-builds]
     steps:
       - name: Set docker image tag 
         run: |

--- a/code/go/0chain.net/blobber/config.go
+++ b/code/go/0chain.net/blobber/config.go
@@ -134,6 +134,8 @@ func setupConfig(configDir string, deploymentMode int) {
 	config.Configuration.Geolocation.Latitude = viper.GetFloat64("geolocation.latitude")
 	config.Configuration.Geolocation.Longitude = viper.GetFloat64("geolocation.longitude")
 
+	config.Configuration.ChallengeCompletionTime = viper.GetDuration("challenge_completion_time")
+
 	fmt.Print("		[OK]\n")
 }
 

--- a/code/go/0chain.net/blobbercore/challenge/challenge.go
+++ b/code/go/0chain.net/blobbercore/challenge/challenge.go
@@ -138,7 +138,9 @@ func processAccepted(ctx context.Context) {
 
 	db := datastore.GetStore().GetDB()
 
-	rows, err := db.Where("status = ?", Accepted).Select("challenge_id", "created_at").Rows()
+	rows, err := db.Model(&ChallengeEntity{}).
+		Where("status = ?", Accepted).
+		Select("challenge_id", "created_at").Rows()
 
 	if err != nil {
 		logging.Logger.Error("[challenge]process: ",
@@ -209,7 +211,9 @@ func validateChallenge(id string) {
 
 	db := datastore.GetStore().GetTransaction(ctx)
 
-	if err := db.Where("challenge_id = ? and status = ?", id, Accepted).Find(c).Error; err != nil {
+	if err := db.Model(&ChallengeEntity{}).
+		Where("challenge_id = ? and status = ?", id, Accepted).
+		Find(c).Error; err != nil {
 
 		logging.Logger.Error("[challenge]validate: ",
 			zap.Any("challenge_id", id),
@@ -275,7 +279,9 @@ func commitProcessed(ctx context.Context) {
 	db := datastore.GetStore().GetDB()
 	count := 0
 
-	rows, err := db.Where("status = ?", Processed).Select("challenge_id", "created_at").Rows()
+	rows, err := db.Model(&ChallengeEntity{}).
+		Where("status = ?", Processed).
+		Select("challenge_id", "created_at").Rows()
 
 	if err != nil {
 		logging.Logger.Error("[challenge]validate: ",
@@ -344,7 +350,9 @@ func commitChallenge(id string) {
 
 	var c *ChallengeEntity
 
-	if err := db.Where("challenge_id = ? and status = ?", id, Processed).Find(c).Error; err != nil {
+	if err := db.Model(&ChallengeEntity{}).
+		Where("challenge_id = ? and status = ?", id, Processed).
+		Find(c).Error; err != nil {
 
 		logging.Logger.Error("[challenge]commit: ",
 			zap.Any("challenge_id", id),

--- a/code/go/0chain.net/blobbercore/challenge/challenge.go
+++ b/code/go/0chain.net/blobbercore/challenge/challenge.go
@@ -237,6 +237,7 @@ func validateChallenge(id string) {
 			zap.String("validationTickets", string(c.ValidationTicketsString)),
 			zap.String("ObjectPath", string(c.ObjectPathString)),
 			zap.Error(err))
+		return
 	}
 
 	if err := c.LoadValidationTickets(ctx); err != nil {
@@ -378,6 +379,7 @@ func commitChallenge(id string) {
 			zap.String("validationTickets", string(c.ValidationTicketsString)),
 			zap.String("ObjectPath", string(c.ObjectPathString)),
 			zap.Error(err))
+		return
 	}
 
 	if err := c.CommitChallenge(ctx, false); err != nil {

--- a/code/go/0chain.net/blobbercore/challenge/challenge.go
+++ b/code/go/0chain.net/blobbercore/challenge/challenge.go
@@ -25,10 +25,9 @@ type BCChallengeResponse struct {
 	Challenges []*ChallengeEntity `json:"challenges"`
 }
 
-var cMap = cache.NewLRUCache(2000) //nolint
+var cMap = cache.NewLRUCache(2000)
 
 // syncOpenChallenges get challenge from blockchain , and add them in database
-// nolint
 func syncOpenChallenges(ctx context.Context) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -79,7 +78,6 @@ func syncOpenChallenges(ctx context.Context) {
 
 }
 
-// nolint
 func saveNewChallenge(c *ChallengeEntity, ctx context.Context) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -130,7 +128,6 @@ func saveNewChallenge(c *ChallengeEntity, ctx context.Context) {
 }
 
 // processAccepted read accepted challenge from db, and send them to validator to pass challenge
-// nolint
 func processAccepted(ctx context.Context) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/code/go/0chain.net/blobbercore/challenge/challenge.go
+++ b/code/go/0chain.net/blobbercore/challenge/challenge.go
@@ -237,6 +237,7 @@ func validateChallenge(id string) {
 			zap.String("validationTickets", string(c.ValidationTicketsString)),
 			zap.String("ObjectPath", string(c.ObjectPathString)),
 			zap.Error(err))
+		db.Rollback()
 		return
 	}
 
@@ -379,6 +380,7 @@ func commitChallenge(id string) {
 			zap.String("validationTickets", string(c.ValidationTicketsString)),
 			zap.String("ObjectPath", string(c.ObjectPathString)),
 			zap.Error(err))
+		db.Rollback()
 		return
 	}
 

--- a/code/go/0chain.net/blobbercore/challenge/challenge.go
+++ b/code/go/0chain.net/blobbercore/challenge/challenge.go
@@ -25,9 +25,10 @@ type BCChallengeResponse struct {
 	Challenges []*ChallengeEntity `json:"challenges"`
 }
 
-var cMap = cache.NewLRUCache(2000)
+var cMap = cache.NewLRUCache(2000) //nolint
 
 // syncOpenChallenges get challenge from blockchain , and add them in database
+// nolint
 func syncOpenChallenges(ctx context.Context) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -78,6 +79,7 @@ func syncOpenChallenges(ctx context.Context) {
 
 }
 
+// nolint
 func saveNewChallenge(c *ChallengeEntity, ctx context.Context) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -121,12 +123,14 @@ func saveNewChallenge(c *ChallengeEntity, ctx context.Context) {
 	logging.Logger.Info("[challenge]elapsed:add ",
 		zap.String("challenge_id", c.ChallengeID),
 		zap.Time("created", c.CreatedAt),
+		zap.Time("start", startTime),
 		zap.String("delay", startTime.Sub(c.CreatedAt).String()),
 		zap.String("save", time.Since(startTime).String()))
 
 }
 
 // processAccepted read accepted challenge from db, and send them to validator to pass challenge
+// nolint
 func processAccepted(ctx context.Context) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -203,6 +207,7 @@ func validateChallenge(swg *sizedwaitgroup.SizedWaitGroup, c *ChallengeEntity) {
 	logging.Logger.Info("[challenge]elapsed:validate ",
 		zap.String("challenge_id", c.ChallengeID),
 		zap.Time("created", c.CreatedAt),
+		zap.Time("start", startTime),
 		zap.String("delay", startTime.Sub(c.CreatedAt).String()),
 		zap.String("save", time.Since(startTime).String()))
 }
@@ -293,6 +298,7 @@ func commitChallenge(c *ChallengeEntity) {
 	logging.Logger.Info("[challenge]elapsed:commit ",
 		zap.String("challenge_id", c.ChallengeID),
 		zap.Time("created", c.CreatedAt),
+		zap.Time("start", startTime),
 		zap.String("delay", startTime.Sub(c.CreatedAt).String()),
 		zap.String("save", time.Since(startTime).String()))
 

--- a/code/go/0chain.net/blobbercore/challenge/challenge.go
+++ b/code/go/0chain.net/blobbercore/challenge/challenge.go
@@ -148,6 +148,8 @@ func processAccepted(ctx context.Context) {
 		return
 	}
 
+	defer rows.Close()
+
 	startTime := time.Now()
 	swg := sizedwaitgroup.New(config.Configuration.ChallengeResolveNumWorkers)
 	count := 0
@@ -290,6 +292,7 @@ func commitProcessed(ctx context.Context) {
 			zap.Error(err))
 		return
 	}
+	defer rows.Close()
 
 	startTime := time.Now()
 	swg := sizedwaitgroup.New(config.Configuration.ChallengeResolveNumWorkers)

--- a/code/go/0chain.net/blobbercore/challenge/entity.go
+++ b/code/go/0chain.net/blobbercore/challenge/entity.go
@@ -25,6 +25,7 @@ const (
 	Accepted ChallengeStatus = iota + 1
 	Processed
 	Committed
+	Cancelled
 )
 
 func (s ChallengeStatus) String() string {
@@ -35,6 +36,8 @@ func (s ChallengeStatus) String() string {
 		return "Processed"
 	case Committed:
 		return "Committed"
+	case Cancelled:
+		return "Cancelled"
 	default:
 		return fmt.Sprintf("%d", int(s))
 	}

--- a/code/go/0chain.net/blobbercore/challenge/entity.go
+++ b/code/go/0chain.net/blobbercore/challenge/entity.go
@@ -77,7 +77,7 @@ type ChallengeEntity struct {
 	AllocationID            string                `gorm:"column:allocation_id;size64;not null" json:"allocation_id"`
 	AllocationRoot          string                `gorm:"column:allocation_root;size:64" json:"allocation_root"`
 	RespondedAllocationRoot string                `gorm:"column:responded_allocation_root;size:64" json:"responded_allocation_root"`
-	Status                  ChallengeStatus       `gorm:"column:status;type:integer;not null;default:0" json:"status"`
+	Status                  ChallengeStatus       `gorm:"column:status;type:integer;not null;default:0;index:idx_status" json:"status"`
 	Result                  ChallengeResult       `gorm:"column:result;type:integer;not null;default:0" json:"result"`
 	StatusMessage           string                `gorm:"column:status_message" json:"status_message"`
 	CommitTxnID             string                `gorm:"column:commit_txn_id;size:64" json:"commit_txn_id"`
@@ -204,6 +204,7 @@ func GetChallengeEntity(ctx context.Context, challengeID string) (*ChallengeEnti
 }
 
 // getStatus check challenge if exists in db
+// nolint
 func getStatus(db *gorm.DB, challengeID string) *ChallengeStatus {
 
 	var status []int

--- a/code/go/0chain.net/blobbercore/challenge/worker.go
+++ b/code/go/0chain.net/blobbercore/challenge/worker.go
@@ -9,9 +9,9 @@ import (
 
 // SetupWorkers start challenge workers
 func SetupWorkers(ctx context.Context) {
-	go startSyncOpen(ctx)
-	go startProcessAccepted(ctx)
-	go startCommitProcessed(ctx)
+	// go startSyncOpen(ctx)
+	// go startProcessAccepted(ctx)
+	// go startCommitProcessed(ctx)
 }
 
 func startCommitProcessed(ctx context.Context) {
@@ -20,7 +20,7 @@ func startCommitProcessed(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-time.After(time.Duration(config.Configuration.ChallengeResolveFreq) * time.Second):
-			//commitProcessed(ctx)
+			commitProcessed(ctx)
 		}
 	}
 }
@@ -31,7 +31,7 @@ func startProcessAccepted(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-time.After(time.Duration(config.Configuration.ChallengeResolveFreq) * time.Second):
-			//	processAccepted(ctx)
+			processAccepted(ctx)
 		}
 	}
 }
@@ -43,7 +43,7 @@ func startSyncOpen(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-time.After(time.Duration(config.Configuration.ChallengeResolveFreq) * time.Second):
-			//syncOpenChallenges(ctx)
+			syncOpenChallenges(ctx)
 		}
 	}
 }

--- a/code/go/0chain.net/blobbercore/challenge/worker.go
+++ b/code/go/0chain.net/blobbercore/challenge/worker.go
@@ -10,8 +10,8 @@ import (
 // SetupWorkers start challenge workers
 func SetupWorkers(ctx context.Context) {
 	go startSyncOpen(ctx)
-	// go startProcessAccepted(ctx)
-	// go startCommitProcessed(ctx)
+	go startProcessAccepted(ctx)
+	go startCommitProcessed(ctx)
 }
 
 func startCommitProcessed(ctx context.Context) {

--- a/code/go/0chain.net/blobbercore/challenge/worker.go
+++ b/code/go/0chain.net/blobbercore/challenge/worker.go
@@ -9,7 +9,7 @@ import (
 
 // SetupWorkers start challenge workers
 func SetupWorkers(ctx context.Context) {
-	// go startSyncOpen(ctx)
+	go startSyncOpen(ctx)
 	// go startProcessAccepted(ctx)
 	// go startCommitProcessed(ctx)
 }

--- a/code/go/0chain.net/blobbercore/challenge/worker.go
+++ b/code/go/0chain.net/blobbercore/challenge/worker.go
@@ -20,7 +20,7 @@ func startCommitProcessed(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-time.After(time.Duration(config.Configuration.ChallengeResolveFreq) * time.Second):
-			commitProcessed(ctx)
+			//commitProcessed(ctx)
 		}
 	}
 }
@@ -31,7 +31,7 @@ func startProcessAccepted(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-time.After(time.Duration(config.Configuration.ChallengeResolveFreq) * time.Second):
-			processAccepted(ctx)
+			//	processAccepted(ctx)
 		}
 	}
 }
@@ -43,7 +43,7 @@ func startSyncOpen(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-time.After(time.Duration(config.Configuration.ChallengeResolveFreq) * time.Second):
-			syncOpenChallenges(ctx)
+			//syncOpenChallenges(ctx)
 		}
 	}
 }

--- a/code/go/0chain.net/blobbercore/config/config.go
+++ b/code/go/0chain.net/blobbercore/config/config.go
@@ -24,6 +24,7 @@ func SetupDefaultConfig() {
 	viper.SetDefault("challenge_response.frequency", 10)
 	viper.SetDefault("challenge_response.num_workers", 5)
 	viper.SetDefault("challenge_response.max_retries", 10)
+	viper.SetDefault("challenge_completion_time", "3m")
 
 	viper.SetDefault("healthcheck.frequency", "60s")
 
@@ -169,6 +170,8 @@ type Config struct {
 	// AutomacitUpdate Whether to automatically update blobber updates to blockchain
 	AutomaticUpdate       bool
 	BlobberUpdateInterval time.Duration
+
+	ChallengeCompletionTime time.Duration
 }
 
 /*Configuration of the system */

--- a/code/go/0chain.net/blobbercore/writemarker/worker.go
+++ b/code/go/0chain.net/blobbercore/writemarker/worker.go
@@ -109,13 +109,16 @@ func startRedeemWriteMarkers(ctx context.Context) {
 	var ticker = time.NewTicker(
 		time.Duration(config.Configuration.WMRedeemFreq) * time.Second,
 	)
+
+	logging.Logger.Info("Redeem writemarkers",
+		zap.Any("numOfWorkers", config.Configuration.WMRedeemNumWorkers))
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			logging.Logger.Info("Trying to redeem writemarkers.",
-				zap.Any("numOfWorkers", config.Configuration.WMRedeemNumWorkers))
+
 			redeemWriteMarkers()
 		}
 	}

--- a/config/0chain_blobber.yaml
+++ b/config/0chain_blobber.yaml
@@ -67,6 +67,8 @@ min_confirmation: 50
 
 block_worker: http://198.18.0.98:9091
 
+challenge_completion_time: 2m
+
 handlers:
   rate_limit: 0 # 10 per second . it can't too small one if a large file is download with blocks
   file_rate_limit: 100 # 100 files per second

--- a/config/0chain_blobber.yaml
+++ b/config/0chain_blobber.yaml
@@ -67,7 +67,7 @@ min_confirmation: 50
 
 block_worker: http://198.18.0.98:9091
 
-challenge_completion_time: 2m
+challenge_completion_time: 3m
 
 handlers:
   rate_limit: 0 # 10 per second . it can't too small one if a large file is download with blocks


### PR DESCRIPTION
### Changes
- mark challenge as `Cancelled` if it is timeout by `cct`

### Fixes
- fixed [panicking issue](https://0chain.slack.com/archives/C01U94VF56Y/p1659477814407939?thread_ts=1659477220.281769&cid=C01U94VF56Y) if there are a lot of waiting challenges in db.


### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/blobber/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- 0chain:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
