### PR TITLE
fix(delete): deleted related commit_meta_txns for foreign keyconstraint

### DIFF
--- a/code/go/0chain.net/blobbercore/allocation/deletefilechange.go
+++ b/code/go/0chain.net/blobbercore/allocation/deletefilechange.go
@@ -83,7 +83,7 @@ func (nf *DeleteFileChange) CommitToFileStore(ctx context.Context) error {
 					Where("allocation_id=? AND content_hash=?", nf.AllocationID, res.ContentHash).
 					Count(&count)
 
-				tx.Model(&reference.CommitMetaTxn{}).Unscoped().Delete("ref_id = ?", res.Id)
+				db.Model(&reference.CommitMetaTxn{}).Delete("ref_id = ?", res.Id)
 
 				if count != 0 && res.ThumbnailHash == "" {
 					continue


### PR DESCRIPTION
### Changes


### Fixes
- fixed https://github.com/0chain/blobber/issues/796:  related commit_meta_txns should be deleted if reference_object is deleted from postgres without soft deletion. the bug was introduced by https://github.com/0chain/blobber/pull/678
 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/blobber/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- 0chain:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
