### PR TITLE
Update count when Lock() is called

### DIFF
--- a/code/go/0chain.net/core/common/lock.go
+++ b/code/go/0chain.net/core/common/lock.go
@@ -19,6 +19,9 @@ type Lock struct {
 
 // Lock Acquire lock
 func (l *Lock) Lock() {
+	l.countMu.Lock()
+	l.count++
+	l.countMu.Unlock()
 	for {
 		l.actualLock.Lock()
 		if l.stale {
@@ -53,15 +56,11 @@ func (m *MapLocker) GetLock(key string) (l *Lock, isNew bool) {
 	valueI, ok := m.m.Load(key)
 	if ok {
 		l = valueI.(*Lock)
-		l.countMu.Lock()
-		l.count++
-		l.countMu.Unlock()
 		return
 	}
 
 	l = &Lock{
 		key:        key,
-		count:      1,
 		pMap:       m,
 		actualLock: new(sync.Mutex),
 		countMu:    new(sync.Mutex),


### PR DESCRIPTION
### Fixes
This PR will fix `lock_exists` error if some process checked for `isNew` and returned if it is `false`.
Issue was, when `lock.Unlock()` is called, it is unable to delete key from sync pool and thus `isNew` is always will be `false` in all subsequent requests, hence resulting in `lock_exists` error.


### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/blobber/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- 0chain:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
