### PR TITLE
API for Challenge Timing Details

### DIFF
--- a/code/go/0chain.net/blobbercore/automigration/automigration.go
+++ b/code/go/0chain.net/blobbercore/automigration/automigration.go
@@ -27,6 +27,7 @@ var tableModels = []tableNameI{
 	new(reference.ShareInfo),
 	new(reference.Collaborator),
 	new(challenge.ChallengeEntity),
+	new(challenge.ChallengeTiming),
 	new(allocation.Allocation),
 	new(allocation.AllocationChange),
 	new(allocation.AllocationChangeCollector),

--- a/code/go/0chain.net/blobbercore/challenge/challenge.go
+++ b/code/go/0chain.net/blobbercore/challenge/challenge.go
@@ -152,6 +152,14 @@ func saveNewChallenges(ctx context.Context, ce []*ChallengeEntity) int {
 				zap.Time("created", createdTime),
 				zap.Error(err))
 		}
+
+		if err := CreateChallengeTiming(c.ChallengeID, c.CreatedAt); err != nil {
+			logging.Logger.Error("[challengetiming]add: ",
+				zap.String("challenge_id", c.ChallengeID),
+				zap.Time("created", createdTime),
+				zap.Error(err))
+		}
+
 		txnCompleteTime := time.Since(txnStartTime)
 
 		logging.Logger.Info("[challenge]elapsed:add ",
@@ -224,6 +232,15 @@ func validateOnValidators(id string) {
 			zap.Error(err))
 		tx.Rollback()
 		return
+	}
+
+	completedValidation := time.Now()
+	if err := UpdateChallengeTimingCompleteValidation(c.ChallengeID, common.Timestamp(completedValidation.Unix())); err != nil {
+		logging.Logger.Error("[challengetiming]validation",
+			zap.Any("challenge_id", c.ChallengeID),
+			zap.Time("created", createdTime),
+			zap.Time("complete_validation", completedValidation),
+			zap.Error(err))
 	}
 
 	logging.Logger.Info("[challenge]validate: ",

--- a/code/go/0chain.net/blobbercore/challenge/timing.go
+++ b/code/go/0chain.net/blobbercore/challenge/timing.go
@@ -123,10 +123,10 @@ func UpdateChallengeTimingTxnVerification(challengeID string, txnVerification co
 	return err
 }
 
-func GetUpdatedChallengeTimings(from common.Timestamp, limit common.Pagination) ([]*ChallengeTiming, error) {
+func GetChallengeTimings(from common.Timestamp, limit common.Pagination) ([]*ChallengeTiming, error) {
 	query := datastore.GetStore().GetDB().Model(&ChallengeTiming{}).
-		Where("updated_at > ?", from).Limit(limit.Limit).Offset(limit.Offset).Order(clause.OrderByColumn{
-		Column: clause.Column{Name: "created_at"},
+		Where("closed_at > ?", from).Limit(limit.Limit).Offset(limit.Offset).Order(clause.OrderByColumn{
+		Column: clause.Column{Name: "closed_at"},
 		Desc:   limit.IsDescending,
 	})
 

--- a/code/go/0chain.net/blobbercore/challenge/timing.go
+++ b/code/go/0chain.net/blobbercore/challenge/timing.go
@@ -9,27 +9,28 @@ import (
 )
 
 type ChallengeTiming struct {
+	// ChallengeID is the challenge ID generated on blockchain.
 	ChallengeID string `gorm:"column:challenge_id;size:64;primaryKey" json:"id"`
 
-	// When generated on blockchain.
+	// CreatedAtChain is when generated on blockchain.
 	CreatedAtChain common.Timestamp `gorm:"created_at_chain" json:"created_at_chain"`
-	// When synchronized and created at blobber.
+	// CreatedAtBlobber is when synchronized and created at blobber.
 	CreatedAtBlobber common.Timestamp `gorm:"created_at_blobber" json:"created_at_blobber"`
-	// When all validation tickets are all received.
+	// CompleteValidation is when all validation tickets are all received.
 	CompleteValidation common.Timestamp `gorm:"complete_validation" json:"complete_validation"`
-	// When challenge response is first sent to blockchain.
+	// TxnSubmission is when challenge response is first sent to blockchain.
 	TxnSubmission common.Timestamp `gorm:"txn_submission" json:"txn_submission"`
-	// When challenge response is verified on blockchain.
-	TxnVerified common.Timestamp `gorm:"txn_verified" json:"txn_verification"`
-	// When challenge is cancelled by blobber due to expiration or bad challenge data (eg. invalid ref or not a file) which is impossible to validate.
+	// TxnVerification is when challenge response is verified on blockchain.
+	TxnVerification common.Timestamp `gorm:"txn_verification" json:"txn_verification"`
+	// Cancelled is when challenge is cancelled by blobber due to expiration or bad challenge data (eg. invalid ref or not a file) which is impossible to validate.
 	Cancelled common.Timestamp `gorm:"cancelled" json:"cancelled"`
-	// When challenge is marked as expired by blobber.
+	// Expiration is when challenge is marked as expired by blobber.
 	Expiration common.Timestamp `gorm:"expiration" json:"expiration"`
 
-	// When challenge is closed (eg. expired, cancelled, or completed/verified). When
+	// ClosedAt is when challenge is closed (eg. expired, cancelled, or completed/verified).
 	ClosedAt common.Timestamp `gorm:"column:closed_at;index:idx_closed_at,sort:desc;" json:"closed"`
 
-	// When row is last updated
+	// UpdatedAt is when row is last updated.
 	UpdatedAt common.Timestamp `gorm:"column:updated_at;index:idx_updated_at,sort:desc;" json:"updated"`
 }
 

--- a/code/go/0chain.net/blobbercore/challenge/timing.go
+++ b/code/go/0chain.net/blobbercore/challenge/timing.go
@@ -1,0 +1,142 @@
+package challenge
+
+import (
+	"fmt"
+	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/datastore"
+	"github.com/0chain/blobber/code/go/0chain.net/core/common"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type ChallengeTiming struct {
+	ChallengeID string `gorm:"column:challenge_id;size:64;primaryKey" json:"id"`
+
+	// When generated on blockchain.
+	CreatedAtChain common.Timestamp `gorm:"created_at_chain" json:"created_at_chain"`
+	// When synchronized and created at blobber.
+	CreatedAtBlobber common.Timestamp `gorm:"created_at_blobber" json:"created_at_blobber"`
+	// When all validation tickets are all received.
+	CompleteValidation common.Timestamp `gorm:"complete_validation" json:"complete_validation"`
+	// When challenge response is first sent to blockchain.
+	TxnSubmission common.Timestamp `gorm:"txn_submission" json:"txn_submission"`
+	// When challenge response is verified on blockchain.
+	TxnVerified common.Timestamp `gorm:"txn_verified" json:"txn_verification"`
+	// When challenge is cancelled by blobber due to expiration or bad challenge data (eg. invalid ref or not a file) which is impossible to validate.
+	Cancelled common.Timestamp `gorm:"cancelled" json:"cancelled"`
+	// When challenge is marked as expired by blobber.
+	Expiration common.Timestamp `gorm:"expiration" json:"expiration"`
+
+	// When row is last updated
+	UpdatedAt common.Timestamp `gorm:"updated_at" json:"updated"`
+}
+
+func (ChallengeTiming) TableName() string {
+	return "challenge_timing"
+}
+
+func (c *ChallengeTiming) BeforeCreate(tx *gorm.DB) error {
+	c.UpdatedAt = common.Now()
+	c.CreatedAtBlobber = common.Now()
+	return nil
+}
+
+func (c *ChallengeTiming) BeforeSave(tx *gorm.DB) error {
+	c.UpdatedAt = common.Now()
+	return nil
+}
+
+func CreateChallengeTiming(challengeID string, createdAt common.Timestamp) error {
+	c := &ChallengeTiming{
+		ChallengeID:    challengeID,
+		CreatedAtChain: createdAt,
+	}
+
+	err := datastore.GetStore().GetDB().Transaction(func(tx *gorm.DB) error {
+		return tx.Create(c).Error
+	})
+
+	return err
+}
+
+func UpdateChallengeTimingCancellation(challengeID string, cancellation common.Timestamp, reason error) error {
+	c := &ChallengeTiming{
+		ChallengeID: challengeID,
+	}
+
+	err := datastore.GetStore().GetDB().Transaction(func(tx *gorm.DB) error {
+		err := tx.Model(&c).Update("cancellation", cancellation).Error
+
+		if err == nil && reason == ErrExpiredCCT {
+			err = tx.Model(&c).Update("expiration", cancellation).Error
+		}
+
+		return err
+	})
+
+	return err
+}
+
+func UpdateChallengeTimingFirstValidation(challengeID string, firstValidation common.Timestamp) error {
+	c := &ChallengeTiming{
+		ChallengeID: challengeID,
+	}
+
+	err := datastore.GetStore().GetDB().Transaction(func(tx *gorm.DB) error {
+		return tx.Model(&c).Update("first_validation", firstValidation).Error
+	})
+
+	return err
+}
+
+func UpdateChallengeTimingCompleteValidation(challengeID string, completeValidation common.Timestamp) error {
+	c := &ChallengeTiming{
+		ChallengeID: challengeID,
+	}
+
+	err := datastore.GetStore().GetDB().Transaction(func(tx *gorm.DB) error {
+		return tx.Model(&c).Update("complete_validation", completeValidation).Error
+	})
+
+	return err
+}
+
+func UpdateChallengeTimingTxnSubmission(challengeID string, txnSubmission common.Timestamp) error {
+	c := &ChallengeTiming{
+		ChallengeID: challengeID,
+	}
+
+	err := datastore.GetStore().GetDB().Transaction(func(tx *gorm.DB) error {
+		return tx.Model(&c).Update("txn_submission", txnSubmission).Error
+	})
+
+	return err
+}
+
+func UpdateChallengeTimingTxnVerification(challengeID string, txnVerification common.Timestamp) error {
+	c := &ChallengeTiming{
+		ChallengeID: challengeID,
+	}
+
+	err := datastore.GetStore().GetDB().Transaction(func(tx *gorm.DB) error {
+		return tx.Model(&c).Update("txn_verification", txnVerification).Error
+	})
+
+	return err
+}
+
+func GetUpdatedChallengeTimings(from common.Timestamp, limit common.Pagination) ([]*ChallengeTiming, error) {
+	query := datastore.GetStore().GetDB().Model(&ChallengeTiming{}).
+		Where("updated_at > ?", from).Limit(limit.Limit).Offset(limit.Offset).Order(clause.OrderByColumn{
+		Column: clause.Column{Name: "created_at"},
+		Desc:   limit.IsDescending,
+	})
+
+	var chs []*ChallengeTiming
+
+	result := query.Find(&chs)
+	if result.Error != nil {
+		return nil, fmt.Errorf("error retrieving updated challenge timings with %v; error: %v",
+			from, result.Error)
+	}
+	return chs, nil
+}

--- a/code/go/0chain.net/blobbercore/handler/challenge_timings.go
+++ b/code/go/0chain.net/blobbercore/handler/challenge_timings.go
@@ -27,5 +27,5 @@ func GetChallengeTimings(ctx context.Context, r *http.Request) (interface{}, err
 		return nil, err
 	}
 
-	return challenge.GetUpdatedChallengeTimings(from, limit), nil
+	return challenge.GetUpdatedChallengeTimings(from, limit)
 }

--- a/code/go/0chain.net/blobbercore/handler/challenge_timings.go
+++ b/code/go/0chain.net/blobbercore/handler/challenge_timings.go
@@ -27,5 +27,5 @@ func GetChallengeTimings(ctx context.Context, r *http.Request) (interface{}, err
 		return nil, err
 	}
 
-	return challenge.GetUpdatedChallengeTimings(from, limit)
+	return challenge.GetChallengeTimings(from, limit)
 }

--- a/code/go/0chain.net/blobbercore/handler/challenge_timings.go
+++ b/code/go/0chain.net/blobbercore/handler/challenge_timings.go
@@ -1,0 +1,31 @@
+package handler
+
+import (
+	"context"
+	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/challenge"
+	"github.com/0chain/blobber/code/go/0chain.net/core/common"
+	"net/http"
+	"strconv"
+)
+
+func GetChallengeTimings(ctx context.Context, r *http.Request) (interface{}, error) {
+	var (
+		fromString = r.URL.Query().Get("from")
+		from       common.Timestamp
+	)
+
+	if fromString != "" {
+		fromI, err := strconv.Atoi(fromString)
+		if err != nil {
+			return nil, common.NewError("invalid_parameters", "from parameter is not valid")
+		}
+		from = common.Timestamp(fromI)
+	}
+
+	limit, err := common.GetOffsetLimitOrderParam(r.URL.Query())
+	if err != nil {
+		return nil, err
+	}
+
+	return challenge.GetUpdatedChallengeTimings(from, limit), nil
+}

--- a/code/go/0chain.net/blobbercore/handler/handler.go
+++ b/code/go/0chain.net/blobbercore/handler/handler.go
@@ -69,6 +69,7 @@ func SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/_statsJSON", common.ToJSONResponse(stats.StatsJSONHandler))
 	r.HandleFunc("/_cleanupdisk", common.ToJSONResponse(WithReadOnlyConnection(CleanupDiskHandler)))
 	r.HandleFunc("/getstats", common.ToJSONResponse(stats.GetStatsHandler))
+	r.HandleFunc("/challengetimings", common.ToJSONResponse(GetChallengeTimings))
 
 	//marketplace related
 	r.HandleFunc("/v1/marketplace/shareinfo/{allocation}", common.ToJSONResponse(WithConnection(InsertShare))).Methods(http.MethodOptions, http.MethodPost)

--- a/code/go/0chain.net/core/common/pagination.go
+++ b/code/go/0chain.net/core/common/pagination.go
@@ -1,0 +1,59 @@
+package common
+
+import (
+	"net/url"
+	"strconv"
+)
+
+const DefaultQueryLimit = 20
+
+type Pagination struct {
+	Offset       int
+	Limit        int
+	IsDescending bool
+}
+
+func GetOffsetLimitOrderParam(values url.Values) (Pagination, error) {
+	var (
+		offsetString = values.Get("offset")
+		limitString  = values.Get("limit")
+		sort         = values.Get("sort")
+
+		limit        = DefaultQueryLimit
+		offset       = 0
+		isDescending = false
+		err          error
+	)
+
+	if offsetString != "" {
+		offset, err = strconv.Atoi(offsetString)
+		if err != nil {
+
+			return Pagination{Limit: DefaultQueryLimit}, NewError("invalid_parameters", "offset parameter is not valid")
+		}
+	}
+
+	if limitString != "" {
+		limit, err = strconv.Atoi(limitString)
+		if err != nil {
+			return Pagination{Limit: DefaultQueryLimit}, NewError("invalid_parameters", "limit parameter is not valid")
+		}
+
+		if limit > DefaultQueryLimit {
+			limit = DefaultQueryLimit
+		}
+	}
+
+	if sort != "" {
+		switch sort {
+		case "desc":
+			isDescending = true
+		case "asc":
+			isDescending = false
+		default:
+			return Pagination{Limit: DefaultQueryLimit}, err
+		}
+	}
+
+	return Pagination{Offset: offset, Limit: limit, IsDescending: isDescending}, nil
+}


### PR DESCRIPTION
### Changes

Add API to serve the challenge timings history. 
This will be used for chart visualisation during load test and potentially on blobber page as a table

### Fixes



### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/blobber/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- 0chain:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
