### PR TITLE
remove GetObjectPath API

### DIFF
--- a/code/go/0chain.net/blobbercore/handler/grpc_handler.go
+++ b/code/go/0chain.net/blobbercore/handler/grpc_handler.go
@@ -93,25 +93,6 @@ func (b *blobberGRPCService) ListEntities(ctx context.Context, req *blobbergrpc.
 	return convert.ListEntitesResponseCreator(resp), nil
 }
 
-func (b *blobberGRPCService) GetObjectPath(ctx context.Context, req *blobbergrpc.GetObjectPathRequest) (*blobbergrpc.GetObjectPathResponse, error) {
-	r, err := http.NewRequest("", "", http.NoBody)
-	if err != nil {
-		return nil, err
-	}
-	httpRequestWithMetaData(r, getGRPCMetaDataFromCtx(ctx), req.Allocation)
-	r.Form = map[string][]string{
-		"path":      {req.Path},
-		"block_num": {req.BlockNum},
-	}
-
-	resp, err := ObjectPathHandler(ctx, r)
-	if err != nil {
-		return nil, err
-	}
-
-	return convert.GetObjectPathResponseCreator(resp), nil
-}
-
 func (b *blobberGRPCService) GetReferencePath(ctx context.Context, req *blobbergrpc.GetReferencePathRequest) (*blobbergrpc.GetReferencePathResponse, error) {
 	r, err := http.NewRequest("", "", http.NoBody)
 	if err != nil {

--- a/code/go/0chain.net/blobbercore/handler/handler.go
+++ b/code/go/0chain.net/blobbercore/handler/handler.go
@@ -171,9 +171,6 @@ func SetupHandlers(r *mux.Router) {
 		RateLimitByObjectRL(common.ToJSONResponse(WithReadOnlyConnection(ListHandler)))).
 		Methods(http.MethodGet, http.MethodOptions)
 
-	r.HandleFunc("/v1/file/objectpath/{allocation}",
-		RateLimitByObjectRL(common.ToJSONResponse(WithReadOnlyConnection(ObjectPathHandler))))
-
 	r.HandleFunc("/v1/file/referencepath/{allocation}",
 		RateLimitByObjectRL(common.ToJSONResponse(WithReadOnlyConnection(ReferencePathHandler))))
 
@@ -357,17 +354,6 @@ func ReferencePathHandler(ctx context.Context, r *http.Request) (interface{}, er
 	ctx = setupHandlerContext(ctx, r)
 
 	response, err := storageHandler.GetReferencePath(ctx, r)
-	if err != nil {
-		return nil, err
-	}
-	return response, nil
-}
-
-func ObjectPathHandler(ctx context.Context, r *http.Request) (interface{}, error) {
-
-	ctx = setupHandlerContext(ctx, r)
-
-	response, err := storageHandler.GetObjectPath(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/code/go/0chain.net/blobbercore/handler/handler_test.go
+++ b/code/go/0chain.net/blobbercore/handler/handler_test.go
@@ -93,11 +93,6 @@ func init() {
 func setupHandlers() (*mux.Router, map[string]string) {
 	router := mux.NewRouter()
 
-	opPath := "/v1/file/objectpath/{allocation}"
-	opName := "Object_Path"
-	router.HandleFunc(opPath, common.ToJSONResponse(
-		WithReadOnlyConnection(ObjectPathHandler))).Name(opName)
-
 	sPath := "/v1/file/stats/{allocation}"
 	sName := "Stats"
 	router.HandleFunc(sPath,
@@ -130,7 +125,6 @@ func setupHandlers() (*mux.Router, map[string]string) {
 
 	return router,
 		map[string]string{
-			opPath:   opName,
 			sPath:    sName,
 			collPath: collName,
 			rPath:    rName,
@@ -512,66 +506,6 @@ func TestHandlers_Requiring_Signature(t *testing.T) {
 	}
 
 	positiveTests := []test{
-		{
-			name: "Object_Path_OK",
-			args: args{
-				w: httptest.NewRecorder(),
-				r: func() *http.Request {
-					handlerName := handlers["/v1/file/objectpath/{allocation}"]
-					url, err := router.Get(handlerName).URL("allocation", alloc.Tx)
-					if err != nil {
-						t.Fatal()
-					}
-					q := url.Query()
-					q.Set("block_num", "0")
-					q.Set("path", path)
-					url.RawQuery = q.Encode()
-
-					r, err := http.NewRequest(http.MethodGet, url.String(), nil)
-					if err != nil {
-						t.Fatal(err)
-					}
-
-					hash := encryption.Hash(alloc.Tx)
-					sign, err := sch.Sign(hash)
-					if err != nil {
-						t.Fatal(err)
-					}
-
-					r.Header.Set(common.ClientSignatureHeader, sign)
-					r.Header.Set(common.ClientHeader, alloc.OwnerID)
-
-					return r
-				}(),
-			},
-			alloc: alloc,
-			setupDbMock: func(mock sqlmock.Sqlmock) {
-				mock.ExpectBegin()
-
-				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "allocations" WHERE`)).
-					WithArgs(alloc.Tx).
-					WillReturnRows(
-						sqlmock.NewRows([]string{"id", "tx", "expiration_date", "owner_public_key", "owner_id"}).
-							AddRow(alloc.ID, alloc.Tx, alloc.Expiration, alloc.OwnerPublicKey, alloc.OwnerID),
-					)
-
-				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "terms" WHERE`)).
-					WithArgs(alloc.ID).
-					WillReturnRows(
-						sqlmock.NewRows([]string{"id", "allocation_id"}).
-							AddRow(alloc.Terms[0].ID, alloc.Terms[0].AllocationID),
-					)
-				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "reference_objects" WHERE`)).
-					WithArgs(alloc.ID, "/", reference.DIRECTORY, alloc.ID, "/").
-					WillReturnRows(
-						sqlmock.NewRows([]string{"path"}).
-							AddRow("/"),
-					)
-
-				mock.ExpectCommit()
-			},
-			wantCode: http.StatusOK,
-		},
 		{
 			name: "Stats_OK",
 			args: args{


### PR DESCRIPTION
### Changes
The `GetObjectPath` is not used anywhere and this can be removed
https://github.com/0chain/blobber/pull/859#discussion_r1003270928

### Fixes



### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/blobber/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- 0chain:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
