### PR TITLE
use correct configuration file on validator conductor container

### DIFF
--- a/docker.local/IntegrationTestsValidatorDockerfile
+++ b/docker.local/IntegrationTestsValidatorDockerfile
@@ -4,7 +4,7 @@ LABEL zchain="validator"
 
 RUN apk add --update --no-cache build-base linux-headers git cmake bash perl grep
 
-ENV SRC_DIR=/blobber
+ENV SRC_DIR=/validator
 ENV GO111MODULE=on
 
 # Download the dependencies:
@@ -25,9 +25,7 @@ RUN apk add gmp gmp-dev openssl-dev
 COPY --from=validator_build  /usr/local/lib/libmcl*.so \
                         /usr/local/lib/libbls*.so \
                         /usr/local/lib/
-ENV APP_DIR=/blobber
+ENV APP_DIR=/validator
 WORKDIR $APP_DIR
 COPY --from=validator_build $APP_DIR/code/go/0chain.net/validator/validator $APP_DIR/bin/validator
-COPY --from=validator_build $APP_DIR/config $APP_DIR/config
-COPY --from=validator_build $APP_DIR/docker.local/keys_config $APP_DIR/keysconfig
 


### PR DESCRIPTION
### Fixes
Change dockerfile of validator conductor image to use the right workspace directory.


### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/blobber/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- 0chain:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
