### PR TITLE
changed response type of API to application/JSON

### DIFF
--- a/code/go/0chain.net/blobbercore/handler/handler_download_test.go
+++ b/code/go/0chain.net/blobbercore/handler/handler_download_test.go
@@ -159,7 +159,7 @@ func TestHandlers_Download(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n\n",
 		}
 		negativeTests = append(negativeTests, emptySignature)
 
@@ -197,7 +197,7 @@ func TestHandlers_Download(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n\n",
 		}
 		negativeTests = append(negativeTests, wrongSignature)
 	}

--- a/code/go/0chain.net/blobbercore/handler/handler_download_test.go
+++ b/code/go/0chain.net/blobbercore/handler/handler_download_test.go
@@ -280,7 +280,7 @@ func TestHandlers_Download(t *testing.T) {
 
 			},
 			wantCode: http.StatusBadRequest,
-			wantBody: "{\"code\":\"download_file\",\"error\":\"download_file: invalid file path: record not found\"}\n\n",
+			wantBody: "{\"code\":\"download_file\",\"error\":\"download_file: invalid file path: record not found\"}\n",
 		},
 		{
 			name: "DownloadFile_Unencrypted_return_file",
@@ -475,7 +475,7 @@ func TestHandlers_Download(t *testing.T) {
 				mock.ExpectCommit()
 			},
 			wantCode: http.StatusBadRequest,
-			wantBody: "{\"code\":\"stale_read_marker\",\"error\":\"stale_read_marker: \"}\n\n",
+			wantBody: "{\"code\":\"stale_read_marker\",\"error\":\"stale_read_marker: \"}\n",
 		},
 		{
 			name: "DownloadFile_Encrypted_Permission_Denied_Unshared_File",
@@ -584,7 +584,7 @@ func TestHandlers_Download(t *testing.T) {
 				mock.ExpectCommit()
 			},
 			wantCode: http.StatusBadRequest,
-			wantBody: "{\"error\":\"client does not have permission to download the file. share does not exist\"}\n\n",
+			wantBody: "{\"error\":\"client does not have permission to download the file. share does not exist\"}\n",
 		},
 		{
 			name: "DownloadFile_Encrypted_Permission_Allowed_shared_File",
@@ -1118,7 +1118,7 @@ func TestHandlers_Download(t *testing.T) {
 
 			},
 			wantCode: http.StatusBadRequest,
-			wantBody: "{\"code\":\"download_file\",\"error\":\"download_file: cannot verify auth ticket: invalid_parameters: Auth ticket is not valid for the resource being requested\"}\n\n",
+			wantBody: "{\"code\":\"download_file\",\"error\":\"download_file: cannot verify auth ticket: invalid_parameters: Auth ticket is not valid for the resource being requested\"}\n",
 		},
 	}
 

--- a/code/go/0chain.net/blobbercore/handler/handler_download_test.go
+++ b/code/go/0chain.net/blobbercore/handler/handler_download_test.go
@@ -159,7 +159,7 @@ func TestHandlers_Download(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n",
 		}
 		negativeTests = append(negativeTests, emptySignature)
 
@@ -197,7 +197,7 @@ func TestHandlers_Download(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n",
 		}
 		negativeTests = append(negativeTests, wrongSignature)
 	}

--- a/code/go/0chain.net/blobbercore/handler/handler_download_test.go
+++ b/code/go/0chain.net/blobbercore/handler/handler_download_test.go
@@ -280,7 +280,7 @@ func TestHandlers_Download(t *testing.T) {
 
 			},
 			wantCode: http.StatusBadRequest,
-			wantBody: "{\"code\":\"download_file\",\"error\":\"download_file: invalid file path: record not found\"}\n",
+			wantBody: "{\"code\":\"download_file\",\"error\":\"download_file: invalid file path: record not found\"}\n\n",
 		},
 		{
 			name: "DownloadFile_Unencrypted_return_file",
@@ -475,7 +475,7 @@ func TestHandlers_Download(t *testing.T) {
 				mock.ExpectCommit()
 			},
 			wantCode: http.StatusBadRequest,
-			wantBody: "{\"code\":\"stale_read_marker\",\"error\":\"stale_read_marker: \"}\n",
+			wantBody: "{\"code\":\"stale_read_marker\",\"error\":\"stale_read_marker: \"}\n\n",
 		},
 		{
 			name: "DownloadFile_Encrypted_Permission_Denied_Unshared_File",
@@ -584,7 +584,7 @@ func TestHandlers_Download(t *testing.T) {
 				mock.ExpectCommit()
 			},
 			wantCode: http.StatusBadRequest,
-			wantBody: "{\"error\":\"client does not have permission to download the file. share does not exist\"}\n",
+			wantBody: "{\"error\":\"client does not have permission to download the file. share does not exist\"}\n\n",
 		},
 		{
 			name: "DownloadFile_Encrypted_Permission_Allowed_shared_File",
@@ -1118,7 +1118,7 @@ func TestHandlers_Download(t *testing.T) {
 
 			},
 			wantCode: http.StatusBadRequest,
-			wantBody: "{\"code\":\"download_file\",\"error\":\"download_file: cannot verify auth ticket: invalid_parameters: Auth ticket is not valid for the resource being requested\"}\n",
+			wantBody: "{\"code\":\"download_file\",\"error\":\"download_file: cannot verify auth ticket: invalid_parameters: Auth ticket is not valid for the resource being requested\"}\n\n",
 		},
 	}
 

--- a/code/go/0chain.net/blobbercore/handler/handler_refpath_test.go
+++ b/code/go/0chain.net/blobbercore/handler/handler_refpath_test.go
@@ -148,7 +148,7 @@ func TestHandlers_ReferencePath(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: could not verify the allocation owner or colloborator\"}\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: could not verify the allocation owner or colloborator\"}\n\n",
 		}
 		negativeTests = append(negativeTests, emptySignature)
 
@@ -192,7 +192,7 @@ func TestHandlers_ReferencePath(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: could not verify the allocation owner or colloborator\"}\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: could not verify the allocation owner or colloborator\"}\n\n",
 		}
 		negativeTests = append(negativeTests, wrongSignature)
 	}

--- a/code/go/0chain.net/blobbercore/handler/handler_refpath_test.go
+++ b/code/go/0chain.net/blobbercore/handler/handler_refpath_test.go
@@ -148,7 +148,7 @@ func TestHandlers_ReferencePath(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: could not verify the allocation owner or colloborator\"}\n\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: could not verify the allocation owner or colloborator\"}\n",
 		}
 		negativeTests = append(negativeTests, emptySignature)
 
@@ -192,7 +192,7 @@ func TestHandlers_ReferencePath(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: could not verify the allocation owner or colloborator\"}\n\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: could not verify the allocation owner or colloborator\"}\n",
 		}
 		negativeTests = append(negativeTests, wrongSignature)
 	}

--- a/code/go/0chain.net/blobbercore/handler/handler_share_test.go
+++ b/code/go/0chain.net/blobbercore/handler/handler_share_test.go
@@ -140,7 +140,7 @@ func TestHandlers_Share(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n\n",
 		}
 		negativeTests = append(negativeTests, emptySignature)
 
@@ -174,7 +174,7 @@ func TestHandlers_Share(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n\n",
 		}
 		negativeTests = append(negativeTests, wrongSignature)
 	}

--- a/code/go/0chain.net/blobbercore/handler/handler_share_test.go
+++ b/code/go/0chain.net/blobbercore/handler/handler_share_test.go
@@ -140,7 +140,7 @@ func TestHandlers_Share(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n",
 		}
 		negativeTests = append(negativeTests, emptySignature)
 
@@ -174,7 +174,7 @@ func TestHandlers_Share(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n",
 		}
 		negativeTests = append(negativeTests, wrongSignature)
 	}

--- a/code/go/0chain.net/blobbercore/handler/handler_test.go
+++ b/code/go/0chain.net/blobbercore/handler/handler_test.go
@@ -336,7 +336,7 @@ func TestHandlers_Requiring_Signature(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n\n",
 		}
 		uploadNegativeTests = append(uploadNegativeTests, emptySignature)
 
@@ -402,7 +402,7 @@ func TestHandlers_Requiring_Signature(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n\n",
 		}
 		uploadNegativeTests = append(uploadNegativeTests, wrongSignature)
 	}
@@ -458,7 +458,7 @@ func TestHandlers_Requiring_Signature(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n\n",
 		}
 		negativeTests = append(negativeTests, emptySignature)
 
@@ -496,7 +496,7 @@ func TestHandlers_Requiring_Signature(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n\n",
 		}
 		negativeTests = append(negativeTests, wrongSignature)
 	}

--- a/code/go/0chain.net/blobbercore/handler/handler_test.go
+++ b/code/go/0chain.net/blobbercore/handler/handler_test.go
@@ -336,7 +336,7 @@ func TestHandlers_Requiring_Signature(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n",
 		}
 		uploadNegativeTests = append(uploadNegativeTests, emptySignature)
 
@@ -402,7 +402,7 @@ func TestHandlers_Requiring_Signature(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n",
 		}
 		uploadNegativeTests = append(uploadNegativeTests, wrongSignature)
 	}
@@ -458,7 +458,7 @@ func TestHandlers_Requiring_Signature(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n",
 		}
 		negativeTests = append(negativeTests, emptySignature)
 
@@ -496,7 +496,7 @@ func TestHandlers_Requiring_Signature(t *testing.T) {
 			alloc:       alloc,
 			setupDbMock: baseSetupDbMock,
 			wantCode:    http.StatusBadRequest,
-			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n\n",
+			wantBody:    "{\"code\":\"invalid_signature\",\"error\":\"invalid_signature: Invalid signature\"}\n",
 		}
 		negativeTests = append(negativeTests, wrongSignature)
 	}

--- a/code/go/0chain.net/core/common/handler.go
+++ b/code/go/0chain.net/core/common/handler.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -47,9 +46,8 @@ func Respond(w http.ResponseWriter, data interface{}, err error) {
 		if cerr, ok := err.(*Error); ok {
 			data["code"] = cerr.Code
 		}
-		buf := bytes.NewBuffer(nil)
-		json.NewEncoder(buf).Encode(data) //nolint:errcheck // checked in previous step
-		http.Error(w, buf.String(), 400)
+		w.WriteHeader(400)
+		json.NewEncoder(w).Encode(data)
 	} else if data != nil {
 		json.NewEncoder(w).Encode(data) //nolint:errcheck // checked in previous step
 	}
@@ -97,7 +95,6 @@ func SetupCORSResponse(w http.ResponseWriter, r *http.Request) {
 func ToJSONResponse(handler JSONResponderF) ReqRespHandlerf {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*") // CORS for all.
-		w.Header().Set("Content-Type", "application/json")
 		if r.Method == "OPTIONS" {
 			SetupCORSResponse(w, r)
 			return

--- a/code/go/0chain.net/core/common/handler.go
+++ b/code/go/0chain.net/core/common/handler.go
@@ -50,8 +50,8 @@ func Respond(w http.ResponseWriter, data interface{}, err error) {
 		}
 		w.WriteHeader(400)
 		buf := bytes.NewBuffer(nil)
-		json.NewEncoder(buf).Encode(data)              //nolint:errcheck // checked in previous step
-		json.NewEncoder(w).Encode(buf.String() + "\n") //nolint:errcheck // checked in previous step
+		json.NewEncoder(buf).Encode(data)       //nolint:errcheck // checked in previous step
+		json.NewEncoder(w).Encode(buf.String()) //nolint:errcheck // checked in previous step
 	} else if data != nil {
 		json.NewEncoder(w).Encode(data) //nolint:errcheck // checked in previous step
 	}

--- a/code/go/0chain.net/core/common/handler.go
+++ b/code/go/0chain.net/core/common/handler.go
@@ -97,6 +97,7 @@ func SetupCORSResponse(w http.ResponseWriter, r *http.Request) {
 func ToJSONResponse(handler JSONResponderF) ReqRespHandlerf {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*") // CORS for all.
+		w.Header().Set("Content-Type", "application/json")
 		if r.Method == "OPTIONS" {
 			SetupCORSResponse(w, r)
 			return

--- a/code/go/0chain.net/core/common/handler.go
+++ b/code/go/0chain.net/core/common/handler.go
@@ -47,7 +47,7 @@ func Respond(w http.ResponseWriter, data interface{}, err error) {
 			data["code"] = cerr.Code
 		}
 		w.WriteHeader(400)
-		json.NewEncoder(w).Encode(data)
+		json.NewEncoder(w).Encode(data) //nolint:errcheck // checked in previous step
 	} else if data != nil {
 		json.NewEncoder(w).Encode(data) //nolint:errcheck // checked in previous step
 	}

--- a/code/go/0chain.net/core/common/handler.go
+++ b/code/go/0chain.net/core/common/handler.go
@@ -50,8 +50,8 @@ func Respond(w http.ResponseWriter, data interface{}, err error) {
 		}
 		w.WriteHeader(400)
 		buf := bytes.NewBuffer(nil)
-		json.NewEncoder(buf).Encode(data)       //nolint:errcheck // checked in previous step
-		json.NewEncoder(w).Encode(buf.String()) //nolint:errcheck // checked in previous step
+		json.NewEncoder(buf).Encode(data)              //nolint:errcheck // checked in previous step
+		json.NewEncoder(w).Encode(buf.String() + "\n") //nolint:errcheck // checked in previous step
 	} else if data != nil {
 		json.NewEncoder(w).Encode(data) //nolint:errcheck // checked in previous step
 	}

--- a/code/go/0chain.net/core/common/handler.go
+++ b/code/go/0chain.net/core/common/handler.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -41,7 +40,6 @@ type JSONReqResponderF func(ctx context.Context, json map[string]interface{}) (i
 func Respond(w http.ResponseWriter, data interface{}, err error) {
 	w.Header().Set("Access-Control-Allow-Origin", "*") // CORS for all.
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("X-Content-Type-Options", "nosniff")
 	if err != nil {
 		data := make(map[string]interface{}, 2)
 		data["error"] = err.Error()
@@ -49,9 +47,7 @@ func Respond(w http.ResponseWriter, data interface{}, err error) {
 			data["code"] = cerr.Code
 		}
 		w.WriteHeader(400)
-		buf := bytes.NewBuffer(nil)
-		json.NewEncoder(buf).Encode(data)              //nolint:errcheck // checked in previous step
-		json.NewEncoder(w).Encode(buf.String() + "\n") //nolint:errcheck // checked in previous step
+		json.NewEncoder(w).Encode(data) //nolint:errcheck // checked in previous step
 	} else if data != nil {
 		json.NewEncoder(w).Encode(data) //nolint:errcheck // checked in previous step
 	}


### PR DESCRIPTION
PR for issue: https://github.com/0chain/blobber/issues/883
```
// Helper handlers

// Error replies to the request with the specified error message and HTTP code.
// It does not otherwise end the request; the caller should ensure no further
// writes are done to w.
// The error message should be plain text.
func Error(w ResponseWriter, error string, code int) {
	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
	w.Header().Set("X-Content-Type-Options", "nosniff")
	w.WriteHeader(code)
	fmt.Fprintln(w, error)
}
```
Removed use of inbuilt function http.Error()