### PR TITLE
show error if destination path does not exist for copy command

### DIFF
--- a/code/go/0chain.net/blobbercore/allocation/copyfilechange.go
+++ b/code/go/0chain.net/blobbercore/allocation/copyfilechange.go
@@ -74,6 +74,12 @@ func (rf *CopyFileChange) ApplyChange(ctx context.Context, change *AllocationCha
 		}
 
 		if !found {
+
+			if change.Operation == constants.FileOperationCopy {
+				return nil, common.NewError("invalid_path",
+						fmt.Sprintf("destpath does not exist."))
+			}
+
 			newRef := reference.NewDirectoryRef()
 			newRef.AllocationID = rf.AllocationID
 			newRef.Path = filepath.Join("/", strings.Join(fields[:i+1], "/"))

--- a/code/go/0chain.net/blobbercore/allocation/copyfilechange.go
+++ b/code/go/0chain.net/blobbercore/allocation/copyfilechange.go
@@ -12,6 +12,8 @@ import (
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/reference"
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/stats"
 	"github.com/0chain/blobber/code/go/0chain.net/core/common"
+
+	"github.com/0chain/gosdk/constants"
 )
 
 type CopyFileChange struct {

--- a/code/go/0chain.net/blobbercore/allocation/copyfilechange.go
+++ b/code/go/0chain.net/blobbercore/allocation/copyfilechange.go
@@ -79,7 +79,7 @@ func (rf *CopyFileChange) ApplyChange(ctx context.Context, change *AllocationCha
 
 			if change.Operation == constants.FileOperationCopy {
 				return nil, common.NewError("invalid_path",
-						fmt.Sprintf("destpath does not exist."))
+						fmt.Sprintf("%s destpath does not exist.", rf.DestPath))
 			}
 
 			newRef := reference.NewDirectoryRef()


### PR DESCRIPTION
### Changes

changing allocation/copyfilechange.go so that if the dest path does not exist in the case of copy command, it should give an error.
### Fixes

https://github.com/0chain/zboxcli/issues/331


### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/blobber/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- 0chain:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
