### PR TITLE
writemarker renamed to allocation root

### DIFF
--- a/code/go/0chain.net/blobbercore/allocation/copyfilechange_test.go
+++ b/code/go/0chain.net/blobbercore/allocation/copyfilechange_test.go
@@ -103,7 +103,7 @@ func TestBlobberCore_CopyFile(t *testing.T) {
 					},
 				)
 
-				q2 := `SELECT "id","allocation_id","type","name","path","parent_path","size","hash","file_meta_hash","path_hash","content_hash","merkle_root","actual_file_size","actual_file_hash","chunk_size","lookup_hash","thumbnail_hash","write_marker","level","created_at","updated_at" FROM "reference_objects" WHERE ((allocation_id=$1 AND parent_path=$2) OR (parent_path = $3 AND allocation_id = $4)) AND "reference_objects"."deleted_at" IS NULL ORDER BY path`
+				q2 := `SELECT "id","allocation_id","type","name","path","parent_path","size","hash","file_meta_hash","path_hash","content_hash","merkle_root","actual_file_size","actual_file_hash","chunk_size","lookup_hash","thumbnail_hash","allocation_root","level","created_at","updated_at" FROM "reference_objects" WHERE ((allocation_id=$1 AND parent_path=$2) OR (parent_path = $3 AND allocation_id = $4)) AND "reference_objects"."deleted_at" IS NULL ORDER BY path`
 				mocket.Catcher.NewMock().WithQuery(q2).WithReply(
 					[]map[string]interface{}{
 						{

--- a/code/go/0chain.net/blobbercore/allocation/file_changer_update.go
+++ b/code/go/0chain.net/blobbercore/allocation/file_changer_update.go
@@ -87,7 +87,7 @@ func (nf *UpdateFileChanger) ApplyChange(ctx context.Context, change *Allocation
 	fileRef.ContentHash = nf.Hash
 	fileRef.CustomMeta = nf.CustomMeta
 	fileRef.MerkleRoot = nf.MerkleRoot
-	fileRef.WriteMarker = allocationRoot
+	fileRef.AllocationRoot = allocationRoot
 	fileRef.Size = nf.Size
 	fileRef.ThumbnailHash = nf.ThumbnailHash
 	fileRef.ThumbnailSize = nf.ThumbnailSize

--- a/code/go/0chain.net/blobbercore/allocation/file_changer_upload.go
+++ b/code/go/0chain.net/blobbercore/allocation/file_changer_upload.go
@@ -96,7 +96,7 @@ func (nf *UploadFileChanger) ApplyChange(ctx context.Context, change *Allocation
 		Type:                reference.FILE,
 		Size:                nf.Size,
 		MimeType:            nf.MimeType,
-		WriteMarker:         allocationRoot,
+		AllocationRoot:      allocationRoot,
 		ThumbnailHash:       nf.ThumbnailHash,
 		ThumbnailSize:       nf.ThumbnailSize,
 		ActualThumbnailHash: nf.ActualThumbnailHash,

--- a/code/go/0chain.net/blobbercore/allocation/movefilechange_test.go
+++ b/code/go/0chain.net/blobbercore/allocation/movefilechange_test.go
@@ -96,7 +96,7 @@ func TestBlobberCore_MoveFile(t *testing.T) {
 					},
 				)
 
-				q2 := `SELECT "id","allocation_id","type","name","path","parent_path","size","hash","file_meta_hash","path_hash","content_hash","merkle_root","actual_file_size","actual_file_hash","chunk_size","lookup_hash","thumbnail_hash","write_marker","level","created_at","updated_at" FROM "reference_objects" WHERE ((allocation_id=$1 AND parent_path=$2) OR (parent_path = $3 AND allocation_id = $4)) AND "reference_objects"."deleted_at" IS NULL ORDER BY path`
+				q2 := `SELECT "id","allocation_id","type","name","path","parent_path","size","hash","file_meta_hash","path_hash","content_hash","merkle_root","actual_file_size","actual_file_hash","chunk_size","lookup_hash","thumbnail_hash","allocation_root","level","created_at","updated_at" FROM "reference_objects" WHERE ((allocation_id=$1 AND parent_path=$2) OR (parent_path = $3 AND allocation_id = $4)) AND "reference_objects"."deleted_at" IS NULL ORDER BY path`
 				mocket.Catcher.NewMock().WithQuery(q2).WithReply(
 					[]map[string]interface{}{
 						{
@@ -180,7 +180,7 @@ func TestBlobberCore_MoveFile(t *testing.T) {
 					},
 				)
 
-				q2 := `SELECT "id","allocation_id","type","name","path","parent_path","size","hash","file_meta_hash","path_hash","content_hash","merkle_root","actual_file_size","actual_file_hash","chunk_size","lookup_hash","thumbnail_hash","write_marker","level","created_at","updated_at" FROM "reference_objects" WHERE ((allocation_id=$1 AND parent_path=$2) OR ("reference_objects"."allocation_id" = $3 AND "reference_objects"."parent_path" = $4) OR (parent_path = $5 AND allocation_id = $6)) AND "reference_objects"."deleted_at" IS NULL ORDER BY path`
+				q2 := `SELECT "id","allocation_id","type","name","path","parent_path","size","hash","file_meta_hash","path_hash","content_hash","merkle_root","actual_file_size","actual_file_hash","chunk_size","lookup_hash","thumbnail_hash","allocation_root","level","created_at","updated_at" FROM "reference_objects" WHERE ((allocation_id=$1 AND parent_path=$2) OR ("reference_objects"."allocation_id" = $3 AND "reference_objects"."parent_path" = $4) OR (parent_path = $5 AND allocation_id = $6)) AND "reference_objects"."deleted_at" IS NULL ORDER BY path`
 				mocket.Catcher.NewMock().WithQuery(q2).WithReply(
 					[]map[string]interface{}{
 						{

--- a/code/go/0chain.net/blobbercore/allocation/renamefilechange_test.go
+++ b/code/go/0chain.net/blobbercore/allocation/renamefilechange_test.go
@@ -218,7 +218,7 @@ func TestBlobberCore_RenameFile(t *testing.T) {
 						},
 					)
 
-				query = `SELECT "id","allocation_id","type","name","path","parent_path","size","hash","file_meta_hash","path_hash","content_hash","merkle_root","actual_file_size","actual_file_hash","chunk_size","lookup_hash","thumbnail_hash","write_marker","level","created_at","updated_at" FROM "reference_objects" WHERE ((allocation_id=$1 AND parent_path=$2) OR (parent_path = $3 AND allocation_id = $4)) AND "reference_objects"."deleted_at" IS NULL ORDER BY path`
+				query = `SELECT "id","allocation_id","type","name","path","parent_path","size","hash","file_meta_hash","path_hash","content_hash","merkle_root","actual_file_size","actual_file_hash","chunk_size","lookup_hash","thumbnail_hash","allocation_root","level","created_at","updated_at" FROM "reference_objects" WHERE ((allocation_id=$1 AND parent_path=$2) OR (parent_path = $3 AND allocation_id = $4)) AND "reference_objects"."deleted_at" IS NULL ORDER BY path`
 				mocket.Catcher.NewMock().OneTime().WithQuery(query).WithReply(
 					[]map[string]interface{}{
 						{
@@ -316,7 +316,7 @@ func TestBlobberCore_RenameFile(t *testing.T) {
 					},
 				)
 
-				query = `SELECT "id","allocation_id","type","name","path","parent_path","size","hash","file_meta_hash","path_hash","content_hash","merkle_root","actual_file_size","actual_file_hash","chunk_size","lookup_hash","thumbnail_hash","write_marker","level","created_at","updated_at" FROM "reference_objects" WHERE ((allocation_id=$1 AND parent_path=$2) OR (parent_path = $3 AND allocation_id = $4)) AND "reference_objects"."deleted_at" IS NULL ORDER BY path`
+				query = `SELECT "id","allocation_id","type","name","path","parent_path","size","hash","file_meta_hash","path_hash","content_hash","merkle_root","actual_file_size","actual_file_hash","chunk_size","lookup_hash","thumbnail_hash","allocation_root","level","created_at","updated_at" FROM "reference_objects" WHERE ((allocation_id=$1 AND parent_path=$2) OR (parent_path = $3 AND allocation_id = $4)) AND "reference_objects"."deleted_at" IS NULL ORDER BY path`
 				mocket.Catcher.NewMock().OneTime().WithQuery(query).WithReply(
 					[]map[string]interface{}{
 						{

--- a/code/go/0chain.net/blobbercore/allocation/updatefilechange_test.go
+++ b/code/go/0chain.net/blobbercore/allocation/updatefilechange_test.go
@@ -63,7 +63,7 @@ func TestBlobberCore_UpdateFile(t *testing.T) {
 			setupDbMock: func() {
 				mocket.Catcher.Reset()
 
-				query := `SELECT "id","allocation_id","type","name","path","parent_path","size","hash","file_meta_hash","path_hash","content_hash","merkle_root","actual_file_size","actual_file_hash","chunk_size","lookup_hash","thumbnail_hash","write_marker","level","created_at","updated_at" FROM "reference_objects" WHERE ((allocation_id=$1 AND parent_path=$2) OR ("reference_objects"."allocation_id" = $3 AND "reference_objects"."parent_path" = $4) OR (parent_path = $5 AND allocation_id = $6)) AND "reference_objects"."deleted_at" IS NULL ORDER BY path`
+				query := `SELECT "id","allocation_id","type","name","path","parent_path","size","hash","file_meta_hash","path_hash","content_hash","merkle_root","actual_file_size","actual_file_hash","chunk_size","lookup_hash","thumbnail_hash","allocation_root","level","created_at","updated_at" FROM "reference_objects" WHERE ((allocation_id=$1 AND parent_path=$2) OR ("reference_objects"."allocation_id" = $3 AND "reference_objects"."parent_path" = $4) OR (parent_path = $5 AND allocation_id = $6)) AND "reference_objects"."deleted_at" IS NULL ORDER BY path`
 				mocket.Catcher.NewMock().WithQuery(query).WithReply(
 					[]map[string]interface{}{
 						{
@@ -121,7 +121,7 @@ func TestBlobberCore_UpdateFile(t *testing.T) {
 			setupDbMock: func() {
 				mocket.Catcher.Reset()
 
-				query := `SELECT "id","allocation_id","type","name","path","parent_path","size","hash","file_meta_hash","path_hash","content_hash","merkle_root","actual_file_size","actual_file_hash","chunk_size","lookup_hash","thumbnail_hash","write_marker","level","created_at","updated_at" FROM "reference_objects" WHERE ((allocation_id=$1 AND parent_path=$2) OR ("reference_objects"."allocation_id" = $3 AND "reference_objects"."parent_path" = $4) OR (parent_path = $5 AND allocation_id = $6)) AND "reference_objects"."deleted_at" IS NULL ORDER BY path`
+				query := `SELECT "id","allocation_id","type","name","path","parent_path","size","hash","file_meta_hash","path_hash","content_hash","merkle_root","actual_file_size","actual_file_hash","chunk_size","lookup_hash","thumbnail_hash","allocation_root","level","created_at","updated_at" FROM "reference_objects" WHERE ((allocation_id=$1 AND parent_path=$2) OR ("reference_objects"."allocation_id" = $3 AND "reference_objects"."parent_path" = $4) OR (parent_path = $5 AND allocation_id = $6)) AND "reference_objects"."deleted_at" IS NULL ORDER BY path`
 				mocket.Catcher.NewMock().WithQuery(query).WithReply(
 					[]map[string]interface{}{
 						{
@@ -178,7 +178,7 @@ func TestBlobberCore_UpdateFile(t *testing.T) {
 			expectingError: false,
 			setupDbMock: func() {
 				mocket.Catcher.Reset()
-				query := `SELECT "id","allocation_id","type","name","path","parent_path","size","hash","file_meta_hash","path_hash","content_hash","merkle_root","actual_file_size","actual_file_hash","chunk_size","lookup_hash","thumbnail_hash","write_marker","level","created_at","updated_at" FROM "reference_objects" WHERE ((allocation_id=$1 AND parent_path=$2) OR ("reference_objects"."allocation_id" = $3 AND "reference_objects"."parent_path" = $4) OR (parent_path = $5 AND allocation_id = $6)) AND "reference_objects"."deleted_at" IS NULL ORDER BY path`
+				query := `SELECT "id","allocation_id","type","name","path","parent_path","size","hash","file_meta_hash","path_hash","content_hash","merkle_root","actual_file_size","actual_file_hash","chunk_size","lookup_hash","thumbnail_hash","allocation_root","level","created_at","updated_at" FROM "reference_objects" WHERE ((allocation_id=$1 AND parent_path=$2) OR ("reference_objects"."allocation_id" = $3 AND "reference_objects"."parent_path" = $4) OR (parent_path = $5 AND allocation_id = $6)) AND "reference_objects"."deleted_at" IS NULL ORDER BY path`
 				mocket.Catcher.NewMock().WithQuery(query).WithReply(
 					[]map[string]interface{}{
 						{

--- a/code/go/0chain.net/blobbercore/handler/storage_handler.go
+++ b/code/go/0chain.net/blobbercore/handler/storage_handler.go
@@ -130,8 +130,8 @@ func (fsh *StorageHandler) GetFileMeta(ctx context.Context, r *http.Request) (in
 	}
 
 	var (
-		isOwner        = clientID == alloc.OwnerID
-		isRepairer     = clientID == alloc.RepairerID
+		isOwner    = clientID == alloc.OwnerID
+		isRepairer = clientID == alloc.RepairerID
 	)
 
 	if isOwner {
@@ -151,8 +151,6 @@ func (fsh *StorageHandler) GetFileMeta(ctx context.Context, r *http.Request) (in
 	}
 
 	result["commit_meta_txns"] = commitMetaTxns
-
-
 
 	if !isOwner && !isRepairer {
 		var authTokenString = r.FormValue("auth_token")
@@ -268,7 +266,7 @@ func (fsh *StorageHandler) GetFileStats(ctx context.Context, r *http.Request) (i
 
 	result := fileref.GetListingData(ctx)
 	fileStats, _ := stats.GetFileStats(ctx, fileref.ID)
-	wm, _ := writemarker.GetWriteMarkerEntity(ctx, fileref.WriteMarker)
+	wm, _ := writemarker.GetWriteMarkerEntity(ctx, fileref.AllocationRoot)
 	if wm != nil && fileStats != nil {
 		fileStats.WriteMarkerRedeemTxn = wm.CloseTxnID
 		fileStats.OnChain = wm.OnChain()

--- a/code/go/0chain.net/blobbercore/reference/ref.go
+++ b/code/go/0chain.net/blobbercore/reference/ref.go
@@ -47,7 +47,7 @@ type Ref struct {
 	ActualFileSize      int64  `gorm:"column:actual_file_size;not null;default:0" filelist:"actual_file_size"`
 	ActualFileHash      string `gorm:"column:actual_file_hash;size:64;not null" filelist:"actual_file_hash"`
 	MimeType            string `gorm:"column:mimetype;size:64;not null" filelist:"mimetype"`
-	WriteMarker         string `gorm:"column:write_marker;size:64;not null"`
+	AllocationRoot      string `gorm:"column:allocation_root;size:64;not null"`
 	ThumbnailSize       int64  `gorm:"column:thumbnail_size;not null;default:0" filelist:"thumbnail_size"`
 	ThumbnailHash       string `gorm:"column:thumbnail_hash;size:64;not null" filelist:"thumbnail_hash"`
 	ActualThumbnailSize int64  `gorm:"column:actual_thumbnail_size;not null;default:0" filelist:"actual_thumbnail_size"`
@@ -106,7 +106,7 @@ type PaginatedRef struct { //Gorm smart select fields.
 	ActualFileSize      int64  `gorm:"column:actual_file_size" json:"actual_file_size,omitempty"`
 	ActualFileHash      string `gorm:"column:actual_file_hash" json:"actual_file_hash,omitempty"`
 	MimeType            string `gorm:"column:mimetype" json:"mimetype,omitempty"`
-	WriteMarker         string `gorm:"column:write_marker" json:"write_marker,omitempty"`
+	AllocationRoot      string `gorm:"column:allocation_root" json:"allocation_root,omitempty"`
 	ThumbnailSize       int64  `gorm:"column:thumbnail_size" json:"thumbnail_size,omitempty"`
 	ThumbnailHash       string `gorm:"column:thumbnail_hash" json:"thumbnail_hash,omitempty"`
 	ActualThumbnailSize int64  `gorm:"column:actual_thumbnail_size" json:"actual_thumbnail_size,omitempty"`
@@ -484,7 +484,7 @@ func (r *Ref) SaveFileRef(ctx context.Context) error {
 		"path_hash":             r.PathHash,
 		"parent_path":           r.ParentPath,
 		"level":                 r.PathLevel,
-		"write_marker":          r.WriteMarker,
+		"allocation_root":       r.AllocationRoot,
 		"mimetype":              r.MimeType,
 		"custom_meta":           r.CustomMeta,
 		"thumbnail_hash":        r.ThumbnailHash,
@@ -510,22 +510,22 @@ func (r *Ref) SaveFileRef(ctx context.Context) error {
 func (r *Ref) SaveDirRef(ctx context.Context) error {
 	db := datastore.GetStore().GetTransaction(ctx)
 	db = db.Model(r).Where("id = ?", r.ID).Updates(map[string]interface{}{
-		"allocation_id":  r.AllocationID,
-		"lookup_hash":    r.LookupHash,
-		"name":           r.Name,
-		"path":           r.Path,
-		"hash":           r.Hash,
-		"file_meta_hash": r.FileMetaHash,
-		"num_of_blocks":  r.NumBlocks,
-		"path_hash":      r.PathHash,
-		"parent_path":    r.ParentPath,
-		"level":          r.PathLevel,
-		"write_marker":   r.WriteMarker,
-		"content_hash":   r.ContentHash,
-		"size":           r.Size,
-		"merkle_root":    r.MerkleRoot,
-		"chunk_size":     r.ChunkSize,
-		"file_id":        r.FileID,
+		"allocation_id":   r.AllocationID,
+		"lookup_hash":     r.LookupHash,
+		"name":            r.Name,
+		"path":            r.Path,
+		"hash":            r.Hash,
+		"file_meta_hash":  r.FileMetaHash,
+		"num_of_blocks":   r.NumBlocks,
+		"path_hash":       r.PathHash,
+		"parent_path":     r.ParentPath,
+		"level":           r.PathLevel,
+		"allocation_root": r.AllocationRoot,
+		"content_hash":    r.ContentHash,
+		"size":            r.Size,
+		"merkle_root":     r.MerkleRoot,
+		"chunk_size":      r.ChunkSize,
+		"file_id":         r.FileID,
 	})
 	if errors.Is(db.Error, gorm.ErrRecordNotFound) || db.RowsAffected == 0 {
 		err := db.Save(r).Error

--- a/code/go/0chain.net/blobbercore/reference/referencepath.go
+++ b/code/go/0chain.net/blobbercore/reference/referencepath.go
@@ -29,7 +29,7 @@ func GetReferenceForHashCalculationFromPaths(ctx context.Context, allocationID s
 	db = db.Model(&Ref{}).Select("id", "allocation_id", "type", "name", "path",
 		"parent_path", "size", "hash", "file_meta_hash", "path_hash", "content_hash", "merkle_root",
 		"actual_file_size", "actual_file_hash", "chunk_size",
-		"lookup_hash", "thumbnail_hash", "write_marker", "level", "created_at", "updated_at")
+		"lookup_hash", "thumbnail_hash", "allocation_root", "level", "created_at", "updated_at")
 
 	pathsAdded := make(map[string]bool)
 	var shouldOr bool


### PR DESCRIPTION
### Changes
As suggested by @lpoli , `Writemarker` in `Ref` struct is renamed to `AllocationRoot`  #957 





### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/blobber/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- 0chain:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
