### PR TITLE
Fix/readmarker issues

### DIFF
--- a/code/go/0chain.net/blobbercore/handler/handler_download_test.go
+++ b/code/go/0chain.net/blobbercore/handler/handler_download_test.go
@@ -362,7 +362,7 @@ func TestHandlers_Download(t *testing.T) {
 					)
 
 				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "read_markers" WHERE`)).
-					WithArgs(ownerClient.ClientID).
+					WithArgs(ownerClient.ClientID, alloc.ID).
 					WillReturnRows(
 						sqlmock.NewRows([]string{"client_id"}).
 							AddRow(ownerClient.ClientID),
@@ -371,7 +371,7 @@ func TestHandlers_Download(t *testing.T) {
 				aa := sqlmock.AnyArg()
 
 				mock.ExpectExec(`UPDATE "read_markers"`).
-					WithArgs(ownerClient.ClientKey, alloc.ID, alloc.OwnerID, aa, aa, aa, aa).
+					WithArgs(aa, aa, aa, aa, aa, aa).
 					WillReturnResult(sqlmock.NewResult(0, 0))
 
 				mock.ExpectCommit()
@@ -459,7 +459,7 @@ func TestHandlers_Download(t *testing.T) {
 					)
 
 				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "read_markers" WHERE`)).
-					WithArgs(ownerClient.ClientID).
+					WithArgs(ownerClient.ClientID, alloc.ID).
 					WillReturnRows(
 						sqlmock.NewRows([]string{"client_id", "counter"}).
 							AddRow(ownerClient.ClientID, 23),
@@ -468,7 +468,7 @@ func TestHandlers_Download(t *testing.T) {
 				aa := sqlmock.AnyArg()
 
 				mock.ExpectExec(`UPDATE "read_markers"`).
-					WithArgs(ownerClient.ClientKey, alloc.ID, alloc.OwnerID, aa, aa, aa, aa, aa).
+					WithArgs(aa, aa, aa, aa).
 					WillReturnResult(sqlmock.NewResult(0, 0))
 
 				mock.ExpectCommit()
@@ -703,7 +703,7 @@ func TestHandlers_Download(t *testing.T) {
 					)
 
 				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "read_markers" WHERE`)).
-					WithArgs(guestClient.ClientID).
+					WithArgs(guestClient.ClientID, alloc.ID).
 					WillReturnRows(
 						sqlmock.NewRows([]string{"client_id"}).
 							AddRow(guestClient.ClientID),
@@ -712,7 +712,7 @@ func TestHandlers_Download(t *testing.T) {
 				aa := sqlmock.AnyArg()
 
 				mock.ExpectExec(`UPDATE "read_markers"`).
-					WithArgs(guestClient.ClientKey, alloc.ID, alloc.OwnerID, aa, aa, aa, aa).
+					WithArgs(aa, aa, aa, aa, aa, aa).
 					WillReturnResult(sqlmock.NewResult(0, 0))
 
 				mock.ExpectCommit()
@@ -845,7 +845,7 @@ func TestHandlers_Download(t *testing.T) {
 					)
 
 				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "read_markers" WHERE`)).
-					WithArgs(guestClient.ClientID).
+					WithArgs(guestClient.ClientID, alloc.ID).
 					WillReturnRows(
 						sqlmock.NewRows([]string{"client_id"}).
 							AddRow(guestClient.ClientID),
@@ -854,7 +854,7 @@ func TestHandlers_Download(t *testing.T) {
 				aa := sqlmock.AnyArg()
 
 				mock.ExpectExec(`UPDATE "read_markers"`).
-					WithArgs(guestClient.ClientKey, alloc.ID, alloc.OwnerID, aa, aa, aa, aa).
+					WithArgs(aa, aa, aa, aa, aa, aa).
 					WillReturnResult(sqlmock.NewResult(0, 0))
 
 				mock.ExpectCommit()
@@ -987,7 +987,7 @@ func TestHandlers_Download(t *testing.T) {
 					)
 
 				mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "read_markers" WHERE`)).
-					WithArgs(guestClient.ClientID).
+					WithArgs(guestClient.ClientID, alloc.ID).
 					WillReturnRows(
 						sqlmock.NewRows([]string{"client_id"}).
 							AddRow(guestClient.ClientID),
@@ -996,7 +996,7 @@ func TestHandlers_Download(t *testing.T) {
 				aa := sqlmock.AnyArg()
 
 				mock.ExpectExec(`UPDATE "read_markers"`).
-					WithArgs(guestClient.ClientKey, alloc.ID, alloc.OwnerID, aa, aa, aa, aa).
+					WithArgs(aa, aa, aa, aa, aa, aa).
 					WillReturnResult(sqlmock.NewResult(0, 0))
 
 				mock.ExpectCommit()

--- a/code/go/0chain.net/blobbercore/handler/object_operation_handler.go
+++ b/code/go/0chain.net/blobbercore/handler/object_operation_handler.go
@@ -232,7 +232,7 @@ func (fsh *StorageHandler) DownloadFile(ctx context.Context, r *http.Request) (r
 		pendNumBlocks int64
 	)
 
-	rme, err = readmarker.GetLatestReadMarkerEntity(ctx, clientID)
+	rme, err = readmarker.GetLatestReadMarkerEntity(ctx, clientID, alloc.ID)
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, common.NewErrorf("download_file", "couldn't get read marker from DB: %v", err)
 	}

--- a/code/go/0chain.net/blobbercore/readmarker/readmarker.go
+++ b/code/go/0chain.net/blobbercore/readmarker/readmarker.go
@@ -133,7 +133,7 @@ func GetLatestReadMarkerEntity(ctx context.Context, clientID, allocID string) (*
 func GetRedeemRequiringRMEntities(ctx context.Context) ([]*ReadMarkerEntity, error) {
 	db := datastore.GetStore().GetTransaction(ctx)
 	var rms []*ReadMarkerEntity
-	err := db.Model(&ReadMarkerEntity{}).Where("counter <> latest_redeemed_rc").Order("created_at asc").Find(&rms).Error
+	err := db.Model(&ReadMarkerEntity{}).Where("counter > latest_redeemed_rc").Order("updated_at asc").Find(&rms).Error
 	if err != nil {
 		return nil, err
 	}

--- a/code/go/0chain.net/blobbercore/readmarker/readmarker.go
+++ b/code/go/0chain.net/blobbercore/readmarker/readmarker.go
@@ -157,7 +157,11 @@ func SaveLatestReadMarker(ctx context.Context, rm *ReadMarker, latestRedeemedRC 
 	if isCreate {
 		return db.Create(rmEntity).Error
 	}
-	return db.Model(rmEntity).Updates(rmEntity).Error
+	return db.Model(rmEntity).Updates(map[string]interface{}{
+		"timestamp": rm.Timestamp,
+		"counter":   rm.ReadCounter,
+		"signature": rm.Signature,
+	}).Error
 }
 
 // Sync read marker with 0chain to be sure its correct.

--- a/code/go/0chain.net/blobbercore/readmarker/worker.go
+++ b/code/go/0chain.net/blobbercore/readmarker/worker.go
@@ -25,8 +25,9 @@ func redeemReadMarker(ctx context.Context, rmEntity *ReadMarkerEntity) (err erro
 	logging.Logger.Info("Redeeming the read marker", zap.Any("rm", rmEntity.LatestRM))
 
 	params := map[string]string{
-		"blobber": rmEntity.LatestRM.BlobberID,
-		"client":  rmEntity.LatestRM.ClientID,
+		"blobber":    rmEntity.LatestRM.BlobberID,
+		"client":     rmEntity.LatestRM.ClientID,
+		"allocation": rmEntity.LatestRM.AllocationID,
 	}
 
 	latestRM := ReadMarker{BlobberID: rmEntity.LatestRM.BlobberID, ClientID: rmEntity.LatestRM.ClientID}


### PR DESCRIPTION
### Changes
Use client id and allocation id as composite primary key to distinguish readmarker for allocation by client.
Modify readmarker retrieving query for redeeming.
Request latest readmarker to chain if record is not found locally.

### Fixes



### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/blobber/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- 0chain: https://github.com/0chain/0chain/pull/2266
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
