### PR TITLE
Do not redeem readmarkers for free reads

### DIFF
--- a/code/go/0chain.net/blobbercore/allocation/entity.go
+++ b/code/go/0chain.net/blobbercore/allocation/entity.go
@@ -139,6 +139,18 @@ func (a *Allocation) GetRequiredWriteBalance(blobberID string, writeSize int64, 
 	return
 }
 
+// IsReadFree Determine if read price is 0
+func (a *Allocation) IsReadFree(blobberID string) bool {
+	for _, d := range a.Terms {
+		if d.BlobberID == blobberID {
+			if d.ReadPrice == 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 type Pending struct {
 	// ID of format client_id:allocation_id
 	ID           string `gorm:"column:id;primaryKey"`

--- a/code/go/0chain.net/blobbercore/handler/download_quota.go
+++ b/code/go/0chain.net/blobbercore/handler/download_quota.go
@@ -67,7 +67,9 @@ func (qm *QuotaManager) consumeQuota(key string, numBlocks int64) error {
 		return err
 	}
 	if dq.Quota == 0 {
+		qm.mux.Lock()
 		delete(qm.m, key)
+		qm.mux.Unlock()
 	}
 	return nil
 }

--- a/code/go/0chain.net/blobbercore/handler/download_request_header.go
+++ b/code/go/0chain.net/blobbercore/handler/download_request_header.go
@@ -24,7 +24,6 @@ type DownloadRequestHeader struct {
 	AuthToken      string
 	VerifyDownload bool
 	DownloadMode   string
-	SubmitRM       bool
 	ConnectionID   string
 }
 
@@ -96,7 +95,6 @@ func (dr *DownloadRequestHeader) Parse(isRedeem bool) error {
 		if err != nil {
 			return errors.Throw(common.ErrInvalidParameter, "X-Read-Marker")
 		}
-		dr.SubmitRM = true
 	} else if isRedeem {
 		return errors.Throw(common.ErrInvalidParameter, "X-Read-Marker")
 	}

--- a/code/go/0chain.net/blobbercore/handler/object_operation_handler.go
+++ b/code/go/0chain.net/blobbercore/handler/object_operation_handler.go
@@ -168,6 +168,8 @@ func (fsh *StorageHandler) RedeemReadMarker(ctx context.Context, r *http.Request
 		allocationTx = ctx.Value(constants.ContextKeyAllocation).(string)
 		allocationID = ctx.Value(constants.ContextKeyAllocationID).(string)
 		alloc        *allocation.Allocation
+		blobberID    = node.Self.ID
+		quotaManager = getQuotaManager()
 	)
 
 	if clientID == "" {
@@ -184,9 +186,17 @@ func (fsh *StorageHandler) RedeemReadMarker(ctx context.Context, r *http.Request
 		return nil, err
 	}
 
-	key := clientID + ":" + alloc.ID
-	quotaManager := getQuotaManager()
+	isReadFree := alloc.IsReadFree(blobberID)
+	if isReadFree {
+		Logger.Info("free_read: readmarker not saved",
+			zap.String("clientID", clientID),
+			zap.String("allocationID", allocationID))
+		return &blobberhttp.DownloadResponse{
+			Success: true,
+		}, nil
+	}
 
+	key := clientID + ":" + alloc.ID
 	lock, isNewLock := readmarker.ReadmarkerMapLock.GetLock(key)
 	if !isNewLock {
 		return nil, common.NewErrorf("lock_exists", fmt.Sprintf("lock exists for key: %v", key))
@@ -264,6 +274,7 @@ func (fsh *StorageHandler) DownloadFile(ctx context.Context, r *http.Request) (i
 		allocationID = ctx.Value(constants.ContextKeyAllocationID).(string)
 		alloc        *allocation.Allocation
 		blobberID    = node.Self.ID
+		quotaManager = getQuotaManager()
 	)
 
 	if clientID == "" {
@@ -288,9 +299,6 @@ func (fsh *StorageHandler) DownloadFile(ctx context.Context, r *http.Request) (i
 	if fileref.Type != reference.FILE {
 		return nil, common.NewErrorf("download_file", "path is not a file: %v", err)
 	}
-
-	key := clientID + ":" + alloc.ID
-	quotaManager := getQuotaManager()
 
 	isOwner := clientID == alloc.OwnerID
 
@@ -324,82 +332,8 @@ func (fsh *StorageHandler) DownloadFile(ctx context.Context, r *http.Request) (i
 	}
 
 	isReadFree := alloc.IsReadFree(blobberID)
-
-	if dr.SubmitRM {
-		if isReadFree {
-			return nil, nil
-		}
-
-		lock, isNewLock := readmarker.ReadmarkerMapLock.GetLock(key)
-		if !isNewLock {
-			return nil, common.NewErrorf("lock_exists", fmt.Sprintf("lock exists for key: %v", key))
-		}
-
-		lock.Lock()
-		defer lock.Unlock()
-
-		// create read marker
-		var (
-			rme              *readmarker.ReadMarkerEntity
-			latestRM         *readmarker.ReadMarker
-			latestRedeemedRC int64
-			pendNumBlocks    int64
-		)
-
-		rme, err = readmarker.GetLatestReadMarkerEntity(ctx, clientID, alloc.ID)
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, common.NewErrorf("download_file", "couldn't get read marker from DB: %v", err)
-		}
-
-		if rme != nil {
-			latestRM = rme.LatestRM
-			latestRedeemedRC = rme.LatestRedeemedRC
-			if pendNumBlocks, err = rme.PendNumBlocks(); err != nil {
-				return nil, common.NewErrorf("download_file", "couldn't get number of blocks pending redeeming: %v", err)
-			}
-		}
-
-		// check out read pool tokens if read_price > 0
-		err = readPreRedeem(ctx, alloc, dr.ReadMarker.SessionRC, pendNumBlocks, clientID)
-		if err != nil {
-			return nil, common.NewErrorf("not_enough_tokens", "pre-redeeming read marker: %v", err)
-		}
-
-		if latestRM != nil && latestRM.ReadCounter+(dr.ReadMarker.SessionRC) > dr.ReadMarker.ReadCounter {
-			latestRM.BlobberID = node.Self.ID
-			return &blobberhttp.DownloadResponse{
-				Success:      false,
-				LatestRM:     latestRM,
-				Path:         fileref.Path,
-				AllocationID: fileref.AllocationID,
-			}, common.NewError("stale_read_marker", "")
-		}
-
-		if dr.ReadMarker.ClientID != clientID {
-			return nil, common.NewError("invalid_client", "header clientID and readmarker clientID are different")
-		}
-
-		rmObj := new(readmarker.ReadMarkerEntity)
-		rmObj.LatestRM = &dr.ReadMarker
-
-		if err = rmObj.VerifyMarker(ctx, alloc); err != nil {
-			return nil, common.NewErrorf("download_file", "invalid read marker, "+"failed to verify the read marker: %v", err)
-		}
-
-		err = readmarker.SaveLatestReadMarker(ctx, &dr.ReadMarker, latestRedeemedRC, latestRM == nil)
-		if err != nil {
-			Logger.Error(err.Error())
-			return nil, common.NewErrorf("download_file", "couldn't save latest read marker")
-		}
-
-		quotaManager.createOrUpdateQuota(dr.ReadMarker.SessionRC, dr.ConnectionID)
-
-		if dr.NumBlocks == 0 {
-			return nil, nil
-		}
-	}
-
 	var dq *DownloadQuota
+
 	if !isReadFree {
 		dq = quotaManager.getDownloadQuota(dr.ConnectionID)
 		if dq == nil {

--- a/code/go/0chain.net/blobbercore/handler/object_operation_handler_test.go
+++ b/code/go/0chain.net/blobbercore/handler/object_operation_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"time"
@@ -48,6 +49,7 @@ func TestDownloadFile(t *testing.T) {
 		mockClientWallet   = "{\"client_id\":\"9a566aa4f8e8c342fed97c8928040a21f21b8f574e5782c28568635ba9c75a85\",\"client_key\":\"40cd10039913ceabacf05a7c60e1ad69bb2964987bc50f77495e514dc451f907c3d8ebcdab20eedde9c8f39b9a1d66609a637352f318552fb69d4b3672516d1a\",\"keys\":[{\"public_key\":\"40cd10039913ceabacf05a7c60e1ad69bb2964987bc50f77495e514dc451f907c3d8ebcdab20eedde9c8f39b9a1d66609a637352f318552fb69d4b3672516d1a\",\"private_key\":\"a3a88aad5d89cec28c6e37c2925560ce160ac14d2cdcf4a4654b2bb358fe7514\"}],\"mnemonics\":\"inside february piece turkey offer merry select combine tissue wave wet shift room afraid december gown mean brick speak grant gain become toy clown\",\"version\":\"1.0\",\"date_created\":\"2021-05-21 17:32:29.484657 +0545 +0545 m=+0.072791323\"}"
 		mockOwnerWallet    = "{\"client_id\":\"5d0229e0141071c1f88785b1faba4b612582f9d446b02e8d893f1e0d0ce92cdc\",\"client_key\":\"aefef5778906680360cf55bf462823367161520ad95ca183445a879a59c9bf0470b74e41fc12f2ee0ce9c19c4e77878d734226918672d089f561ecf1d5435720\",\"keys\":[{\"public_key\":\"aefef5778906680360cf55bf462823367161520ad95ca183445a879a59c9bf0470b74e41fc12f2ee0ce9c19c4e77878d734226918672d089f561ecf1d5435720\",\"private_key\":\"4f8af6fb1098a3817d705aef96db933f31755674b00a5d38bb2439c0a27b0117\"}],\"mnemonics\":\"erode transfer noble civil ridge cloth sentence gauge board wheel sight caution okay sand ranch ice frozen frown grape lion feed fox game zone\",\"version\":\"1.0\",\"date_created\":\"2021-09-04T14:11:06+01:00\"}"
 		mockReadPrice      = int64(0.1 * 1e10)
+		mockReadPriceFree  = int64(0)
 		mockWritePrice     = int64(0.5 * 1e10)
 		mockBigBalance     = int64(10000 * 1e10)
 	)
@@ -106,27 +108,11 @@ func TestDownloadFile(t *testing.T) {
 		t *testing.T,
 		req *http.Request,
 		p parameters,
-	) *marker.ReadMarker {
-		rm := &marker.ReadMarker{}
-		rm.ClientID = client.GetClientID()
-		rm.ClientPublicKey = client.GetClientPublicKey()
-		rm.BlobberID = p.inData.blobber.ID
-		rm.AllocationID = p.inData.allocationID
-		rm.OwnerID = mockOwner.ClientID
-		rm.Timestamp = now
-		// set another value to size
-		rm.ReadCounter = p.inData.numBlocks
-		rm.SessionRC = p.inData.numBlocks
-		err := rm.Sign()
-		require.NoError(t, err)
-		rmData, err := json.Marshal(rm)
-		require.NoError(t, err)
+	) {
 		req.Header.Set("X-Path-Hash", p.inData.pathHash)
 		req.Header.Set("X-Path", p.inData.remotefilepath)
 		req.Header.Set("X-Block-Num", fmt.Sprintf("%d", p.inData.blockNum))
 		req.Header.Set("X-Num-Blocks", fmt.Sprintf("%d", p.inData.numBlocks))
-		req.Header.Set("X-Submit-RM", fmt.Sprint(true))
-		req.Header.Set("X-Read-Marker", string(rmData))
 		req.Header.Set(common.AllocationIdHeader, mockAllocationId)
 
 		if p.useAuthTicket {
@@ -147,7 +133,6 @@ func TestDownloadFile(t *testing.T) {
 		if len(p.inData.contentMode) > 0 {
 			req.Header.Set("X-Mode", p.inData.contentMode)
 		}
-		return rm
 	}
 
 	makeMockMakeSCRestAPICall := func(t *testing.T, p parameters) func(scAddress string, relativePath string, params map[string]string, chain *chain.Chain) ([]byte, error) {
@@ -184,7 +169,6 @@ func TestDownloadFile(t *testing.T) {
 	setupInMock := func(
 		t *testing.T,
 		p parameters,
-		rm marker.ReadMarker,
 	) {
 		if p.isRepairer {
 			mocket.Catcher.NewMock().OneTime().WithQuery(
@@ -215,17 +199,31 @@ func TestDownloadFile(t *testing.T) {
 			)
 		}
 
-		mocket.Catcher.NewMock().OneTime().WithQuery(
-			`SELECT * FROM "terms" WHERE`,
-		).WithArgs(
-			"mock_allocation_id",
-		).OneTime().WithReply(
-			[]map[string]interface{}{{
-				"blobber_id":  mockBlobberId,
-				"read_price":  mockReadPrice,
-				"write_price": mockWritePrice,
-			}},
-		)
+		if p.isFunded0Chain || p.isFundedBlobber {
+			mocket.Catcher.NewMock().OneTime().WithQuery(
+				`SELECT * FROM "terms" WHERE`,
+			).WithArgs(
+				"mock_allocation_id",
+			).OneTime().WithReply(
+				[]map[string]interface{}{{
+					"blobber_id":  mockBlobberId,
+					"read_price":  mockReadPriceFree,
+					"write_price": mockWritePrice,
+				}},
+			)
+		} else {
+			mocket.Catcher.NewMock().OneTime().WithQuery(
+				`SELECT * FROM "terms" WHERE`,
+			).WithArgs(
+				"mock_allocation_id",
+			).OneTime().WithReply(
+				[]map[string]interface{}{{
+					"blobber_id":  mockBlobberId,
+					"read_price":  mockReadPrice,
+					"write_price": mockWritePrice,
+				}},
+			)
+		}
 
 		mocket.Catcher.NewMock().OneTime().WithQuery(
 			`SELECT * FROM "reference_objects" WHERE`,
@@ -282,29 +280,7 @@ func TestDownloadFile(t *testing.T) {
 	setupOutMock := func(
 		t *testing.T,
 		p parameters,
-		rm marker.ReadMarker,
 	) {
-
-		mocket.Catcher.NewMock().WithCallback(func(par1 string, args []driver.NamedValue) {
-			require.EqualValues(t, client.GetClientID(), args[0].Value)
-			require.EqualValues(t, mockAllocationId, args[1].Value)
-			require.EqualValues(t, client.GetClientPublicKey(), args[2].Value)
-			require.EqualValues(t, mockOwner.ClientID, args[3].Value)
-			require.EqualValues(t, now, args[4].Value)
-			require.EqualValues(t, p.inData.numBlocks, args[5].Value)
-		}).WithQuery(`INSERT INTO "read_markers"`).WithID(11)
-
-		mocket.Catcher.NewMock().WithCallback(func(par1 string, args []driver.NamedValue) {
-			//require.EqualValues(t, p.payerId.ClientKey, args[0].Value)
-			require.EqualValues(t, client.GetClientPublicKey(), args[0].Value)
-			// require.EqualValues(t, mockBlobberId, args[1].Value)
-			require.EqualValues(t, mockAllocationId, args[1].Value)
-			require.EqualValues(t, mockOwner.ClientID, args[2].Value)
-			require.EqualValues(t, now, args[3].Value)
-			require.EqualValues(t, p.inData.numBlocks, args[4].Value)
-			require.EqualValues(t, p.payerId.ClientID, args[6].Value)
-		}).WithQuery(`UPDATE "read_markers" SET`).WithID(1)
-
 		mocket.Catcher.NewMock().WithQuery(`UPDATE "file_stats" SET`).WithID(1)
 	}
 
@@ -319,10 +295,10 @@ func TestDownloadFile(t *testing.T) {
 		return ctx
 	}
 
-	setupRequest := func(p parameters) (*http.Request, *marker.ReadMarker) {
+	setupRequest := func(p parameters) *http.Request {
 		req := httptest.NewRequest(http.MethodGet, "/v1/file/download/", nil)
-		rm := addToForm(t, req, p)
-		return req, rm
+		addToForm(t, req, p)
+		return req
 	}
 
 	setupParams := func(p *parameters) {
@@ -333,7 +309,7 @@ func TestDownloadFile(t *testing.T) {
 			remotefilepath: mockRemoteFilePath,
 			blockNum:       mockBlockNumber,
 			encryptedKey:   mockEncryptKey,
-			contentMode:    "",
+			contentMode:    DownloadContentFull,
 			numBlocks:      1,
 		}
 		if p.isRepairer {
@@ -392,7 +368,7 @@ func TestDownloadFile(t *testing.T) {
 			},
 			want: want{
 				err:    true,
-				errMsg: "not_enough_tokens: pre-redeeming read marker: read_pre_redeem: not enough tokens in client's read pools associated with the allocation->blobber",
+				errMsg: "download_file: no download quota for ",
 			},
 		},
 		{
@@ -480,16 +456,17 @@ func TestDownloadFile(t *testing.T) {
 					require.NoError(t, client.PopulateClient(mockClientWallet, "bls0chain"))
 				}
 				transaction.MakeSCRestAPICall = makeMockMakeSCRestAPICall(t, test.parameters)
-				request, rm := setupRequest(test.parameters)
+				request := setupRequest(test.parameters)
 				datastore.MocketTheStore(t, mocketLogging)
-				setupInMock(t, test.parameters, *rm)
-				setupOutMock(t, test.parameters, *rm)
+				setupInMock(t, test.parameters)
+				setupOutMock(t, test.parameters)
 
 				ctx := setupCtx(test.parameters)
 				ctx = context.WithValue(ctx, constants.ContextKeyAllocationID, mockAllocationId)
 
 				var sh StorageHandler
 				_, err := sh.DownloadFile(ctx, request)
+				log.Println("==============", err)
 
 				require.EqualValues(t, test.want.err, err != nil)
 				if err != nil {


### PR DESCRIPTION
### Changes
- Readmarkers won't be redeemed if reading is free
- Also removed readmarker handling from DownloadFile method, since redeeming readmarkers was moved to a separate handler


### Fixes



### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/blobber/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- 0chain:
- gosdk: https://github.com/0chain/gosdk/pull/1101
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
