### PR TITLE
Using Ubuntu Multi Runner for Building Images

### DIFF
--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -88,7 +88,7 @@ jobs:
           export DOCKER_IMAGE_SWAGGER="${BLOBBER_REGISTRY}:swagger_test"
           export DOCKER_BUILD="buildx build --platform linux/amd64,linux/arm64 --push"
           export DOCKER_IMAGE_BLOBBER="-t ${BLOBBER_REGISTRY}:${TAG} -t ${BLOBBER_REGISTRY}:${TAG}-${SHORT_SHA}"
-          docker buildx create --driver-opt network=host --use --buildkitd-flags '--allow-insecure-entitlement security.insecure' --use blobber_buildx
+          docker buildx create --driver-opt network=host --buildkitd-flags '--allow-insecure-entitlement security.insecure' --use "$RUNNER_NAME"
           ./docker.local/bin/build.blobber.sh
 
   validator:
@@ -157,7 +157,7 @@ jobs:
           export DOCKER_IMAGE_BASE="${VALIDATOR_REGISTRY}:base"
           export DOCKER_BUILD="buildx build --platform linux/amd64,linux/arm64 --push"
           export DOCKER_IMAGE_VALIDATOR="-t ${VALIDATOR_REGISTRY}:${TAG} -t ${VALIDATOR_REGISTRY}:${TAG}-${SHORT_SHA}"
-          docker buildx create --driver-opt network=host --use --buildkitd-flags '--allow-insecure-entitlement security.insecure' --use blobber_buildx
+          docker buildx create --driver-opt network=host --buildkitd-flags '--allow-insecure-entitlement security.insecure' --use "$RUNNER_NAME"
           ./docker.local/bin/build.validator.sh
 
 

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -37,7 +37,7 @@ jobs:
           echo "SHA=$([ -z '${{ github.event.pull_request.head.sha }}' ] && echo $GITHUB_SHA || echo '${{ github.event.pull_request.head.sha }}')" >> $GITHUB_ENV
 
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ^1.20 # The Go version to download (if necessary) and use.
 
@@ -46,13 +46,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      -
-        # Add support for more platforms with QEMU (optional)
-        # https://github.com/docker/setup-qemu-action
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
       - name: Login to Docker Hub
@@ -110,7 +104,7 @@ jobs:
           echo "SHA=$([ -z '${{ github.event.pull_request.head.sha }}' ] && echo $GITHUB_SHA || echo '${{ github.event.pull_request.head.sha }}')" >> $GITHUB_ENV
 
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ^1.20 # The Go version to download (if necessary) and use.
 
@@ -119,13 +113,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      -
-        # Add support for more platforms with QEMU (optional)
-        # https://github.com/docker/setup-qemu-action
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v1

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -27,9 +27,8 @@ jobs:
       - name: Cleanup before restarting conductor tests.
         run: |
           echo 'y' | docker system prune -a
-          rm -rf *
           cd /tmp
-          rm -rf ./*
+          sudo rm -rf ./*
 
       - name: Set docker image tag
         run: |
@@ -101,9 +100,8 @@ jobs:
       - name: Cleanup before restarting conductor tests.
         run: |
           echo 'y' | docker system prune -a
-          rm -rf *
           cd /tmp
-          rm -rf ./*
+          sudo rm -rf ./*
 
       - name: Set docker image tag
         run: |

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -51,7 +51,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install wget
           sudo apt-get install ca-certificates curl gnupg lsb-release -y
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+          rm -f /usr/share/keyrings/docker-archive-keyring.gpg && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update -y
           sudo apt-get install docker-ce docker-ce-cli containerd.io -y
@@ -126,7 +126,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install wget
           sudo apt-get install ca-certificates curl gnupg lsb-release -y
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+          rm -f /usr/share/keyrings/docker-archive-keyring.gpg && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get update -y
           sudo apt-get install docker-ce docker-ce-cli containerd.io -y

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   blobber:
     timeout-minutes: 25
-    runs-on: [self-hosted, arc-runner]
+    runs-on: [Ubuntu-2004-focal-64-minimal]
     steps:
       - name: Set docker image tag
         run: |
@@ -97,7 +97,7 @@ jobs:
 
   validator:
     timeout-minutes: 20
-    runs-on: [self-hosted, arc-runner]
+    runs-on: [Ubuntu-2004-focal-64-minimal]
     steps:
       - name: Set docker image tag 
         run: |

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Cleanup before restarting conductor tests.
         run: |
           echo 'y' | docker system prune -a
-          rm -rf *
           cd /tmp
           rm -rf ./*
 

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -88,7 +88,8 @@ jobs:
           export DOCKER_IMAGE_SWAGGER="${BLOBBER_REGISTRY}:swagger_test"
           export DOCKER_BUILD="buildx build --platform linux/amd64,linux/arm64 --push"
           export DOCKER_IMAGE_BLOBBER="-t ${BLOBBER_REGISTRY}:${TAG} -t ${BLOBBER_REGISTRY}:${TAG}-${SHORT_SHA}"
-          docker buildx create --driver-opt network=host --buildkitd-flags '--allow-insecure-entitlement security.insecure' --use "$RUNNER_NAME"
+          export CONTEXT_NAME="$RUNNER_NAME" && (docker context inspect "$CONTEXT_NAME" >/dev/null 2>&1 || docker context create "$CONTEXT_NAME")
+          docker buildx create --driver-opt network=host --buildkitd-flags '--allow-insecure-entitlement security.insecure' --use "$CONTEXT_NAME"
           ./docker.local/bin/build.blobber.sh
 
   validator:
@@ -157,7 +158,8 @@ jobs:
           export DOCKER_IMAGE_BASE="${VALIDATOR_REGISTRY}:base"
           export DOCKER_BUILD="buildx build --platform linux/amd64,linux/arm64 --push"
           export DOCKER_IMAGE_VALIDATOR="-t ${VALIDATOR_REGISTRY}:${TAG} -t ${VALIDATOR_REGISTRY}:${TAG}-${SHORT_SHA}"
-          docker buildx create --driver-opt network=host --buildkitd-flags '--allow-insecure-entitlement security.insecure' --use "$RUNNER_NAME"
+          export CONTEXT_NAME="$RUNNER_NAME" && (docker context inspect "$CONTEXT_NAME" >/dev/null 2>&1 || docker context create "$CONTEXT_NAME")
+          docker buildx create --driver-opt network=host --buildkitd-flags '--allow-insecure-entitlement security.insecure' --use "$CONTEXT_NAME"
           ./docker.local/bin/build.validator.sh
 
 

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   blobber:
     timeout-minutes: 30
-    runs-on: [Ubuntu-2004-focal-64-minimal]
+    runs-on: [blobber-runner]
     steps:
       - name: Set docker image tag
         run: |
@@ -89,7 +89,7 @@ jobs:
 
   validator:
     timeout-minutes: 30
-    runs-on: [Ubuntu-2004-focal-64-minimal]
+    runs-on: [blobber-runner]
     steps:
       - name: Set docker image tag 
         run: |

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Cleanup before restarting conductor tests.
         run: |
           echo 'y' | docker system prune -a
+          rm -rf *
           cd /tmp
           rm -rf ./*
 

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -46,19 +46,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Docker Buildx
-        run: |
-          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get update -y"
-          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install wget git -y"
-          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install ca-certificates curl gnupg lsb-release -y"
-          rm -f /usr/share/keyrings/docker-archive-keyring.gpg && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get update -y"
-          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install docker-ce docker-ce-cli containerd.io -y"
-          export DOCKER_CLI_EXPERIMENTAL=enabled
-          docker run --privileged --rm tonistiigi/binfmt --install all
-          CONTEXT_NAME="blobber_buildx" && (docker context inspect "$CONTEXT_NAME" >/dev/null 2>&1 || docker context create "$CONTEXT_NAME")
-
+      -
+        # Add support for more platforms with QEMU (optional)
+        # https://github.com/docker/setup-qemu-action
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -121,19 +117,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Docker Buildx
-        run: |
-          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get update -y"
-          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install wget git -y"
-          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install ca-certificates curl gnupg lsb-release -y"
-          rm -f /usr/share/keyrings/docker-archive-keyring.gpg && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get update -y"
-          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install docker-ce docker-ce-cli containerd.io -y"
-          export DOCKER_CLI_EXPERIMENTAL=enabled
-          docker run --privileged --rm tonistiigi/binfmt --install all
-          CONTEXT_NAME="blobber_buildx" && (docker context inspect "$CONTEXT_NAME" >/dev/null 2>&1 || docker context create "$CONTEXT_NAME")
-
+      -
+        # Add support for more platforms with QEMU (optional)
+        # https://github.com/docker/setup-qemu-action
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -5,9 +5,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push: 
+  push:
     branches: [ master,staging, sprint* ]
-    tags: 
+    tags:
       - '*'
   pull_request:
   workflow_dispatch:
@@ -24,6 +24,13 @@ jobs:
     timeout-minutes: 30
     runs-on: [blobber-runner]
     steps:
+      - name: Cleanup before restarting conductor tests.
+        run: |
+          echo 'y' | docker system prune -a
+          rm -rf *
+          cd /tmp
+          rm -rf ./*
+
       - name: Set docker image tag
         run: |
           if [[ "${{github.ref}}" == refs/pull/* ]]; then
@@ -48,7 +55,7 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -91,7 +98,14 @@ jobs:
     timeout-minutes: 30
     runs-on: [blobber-runner]
     steps:
-      - name: Set docker image tag 
+      - name: Cleanup before restarting conductor tests.
+        run: |
+          echo 'y' | docker system prune -a
+          rm -rf *
+          cd /tmp
+          rm -rf ./*
+
+      - name: Set docker image tag
         run: |
           if [[ "${{github.ref}}" == refs/pull/* ]]; then
             tag=${GITHUB_REF/\/merge/}
@@ -135,7 +149,7 @@ jobs:
         run: |
           SHORT_SHA=$(echo ${{ env.SHA }} | head -c 8)
 
-          ./docker.local/bin/build.base.sh 
+          ./docker.local/bin/build.base.sh
           docker tag $BLOBBER_BUILDBASE $BLOBBER_BUILD_BASE_REGISTRY:$TAG
           docker tag $BLOBBER_BUILDBASE $BLOBBER_BUILD_BASE_REGISTRY:$TAG-$SHORT_SHA
           docker push $BLOBBER_BUILD_BASE_REGISTRY:$TAG

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Docker Buildx
         run: |
           sudo flock /var/lib/apt/lists/lock -c "sudo apt-get update -y"
-          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install wget"
+          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install wget git -y"
           sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install ca-certificates curl gnupg lsb-release -y"
           rm -f /usr/share/keyrings/docker-archive-keyring.gpg && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
@@ -57,7 +57,7 @@ jobs:
           sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install docker-ce docker-ce-cli containerd.io -y"
           export DOCKER_CLI_EXPERIMENTAL=enabled
           docker run --privileged --rm tonistiigi/binfmt --install all
-          docker context create blobber_buildx
+          CONTEXT_NAME="blobber_buildx" && (docker context inspect "$CONTEXT_NAME" >/dev/null 2>&1 || docker context create "$CONTEXT_NAME")
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1
@@ -124,7 +124,7 @@ jobs:
       - name: Set up Docker Buildx
         run: |
           sudo flock /var/lib/apt/lists/lock -c "sudo apt-get update -y"
-          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install wget"
+          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install wget git -y"
           sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install ca-certificates curl gnupg lsb-release -y"
           rm -f /usr/share/keyrings/docker-archive-keyring.gpg && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
@@ -132,7 +132,7 @@ jobs:
           sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install docker-ce docker-ce-cli containerd.io -y"
           export DOCKER_CLI_EXPERIMENTAL=enabled
           docker run --privileged --rm tonistiigi/binfmt --install all
-          docker context create blobber_buildx
+          CONTEXT_NAME="blobber_buildx" && (docker context inspect "$CONTEXT_NAME" >/dev/null 2>&1 || docker context create "$CONTEXT_NAME")
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -48,13 +48,13 @@ jobs:
 
       - name: Set up Docker Buildx
         run: |
-          sudo apt-get update -y
-          sudo apt-get install wget
-          sudo apt-get install ca-certificates curl gnupg lsb-release -y
+          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get update -y"
+          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install wget"
+          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install ca-certificates curl gnupg lsb-release -y"
           rm -f /usr/share/keyrings/docker-archive-keyring.gpg && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update -y
-          sudo apt-get install docker-ce docker-ce-cli containerd.io -y
+          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get update -y"
+          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install docker-ce docker-ce-cli containerd.io -y"
           export DOCKER_CLI_EXPERIMENTAL=enabled
           docker run --privileged --rm tonistiigi/binfmt --install all
           docker context create blobber_buildx
@@ -123,13 +123,13 @@ jobs:
 
       - name: Set up Docker Buildx
         run: |
-          sudo apt-get update -y
-          sudo apt-get install wget
-          sudo apt-get install ca-certificates curl gnupg lsb-release -y
+          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get update -y"
+          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install wget"
+          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install ca-certificates curl gnupg lsb-release -y"
           rm -f /usr/share/keyrings/docker-archive-keyring.gpg && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update -y
-          sudo apt-get install docker-ce docker-ce-cli containerd.io -y
+          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get update -y"
+          sudo flock /var/lib/apt/lists/lock -c "sudo apt-get install docker-ce docker-ce-cli containerd.io -y"
           export DOCKER_CLI_EXPERIMENTAL=enabled
           docker run --privileged --rm tonistiigi/binfmt --install all
           docker context create blobber_buildx

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   blobber:
-    timeout-minutes: 25
+    timeout-minutes: 30
     runs-on: [Ubuntu-2004-focal-64-minimal]
     steps:
       - name: Set docker image tag
@@ -93,7 +93,7 @@ jobs:
           ./docker.local/bin/build.blobber.sh
 
   validator:
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: [Ubuntu-2004-focal-64-minimal]
     steps:
       - name: Set docker image tag 

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -89,8 +89,8 @@ jobs:
           export DOCKER_BUILD="buildx build --platform linux/amd64,linux/arm64 --push"
           export DOCKER_IMAGE_BLOBBER="-t ${BLOBBER_REGISTRY}:${TAG} -t ${BLOBBER_REGISTRY}:${TAG}-${SHORT_SHA}"
           export CONTEXT_NAME="$RUNNER_NAME" && (docker context inspect "$CONTEXT_NAME" >/dev/null 2>&1 || docker context create "$CONTEXT_NAME")
-          docker buildx inspect blobber || docker buildx create --name blobber --driver-opt network=host --buildkitd-flags '--allow-insecure-entitlement security.insecure' "$CONTEXT_NAME"
-          docker buildx use blobber
+          docker buildx inspect "blobber-$RUNNER_NAME" || docker buildx create --name "blobber-$RUNNER_NAME" --driver-opt network=host --buildkitd-flags '--allow-insecure-entitlement security.insecure' "$CONTEXT_NAME"
+          docker buildx use "blobber-$RUNNER_NAME"
           ./docker.local/bin/build.blobber.sh
 
   validator:
@@ -160,8 +160,8 @@ jobs:
           export DOCKER_BUILD="buildx build --platform linux/amd64,linux/arm64 --push"
           export DOCKER_IMAGE_VALIDATOR="-t ${VALIDATOR_REGISTRY}:${TAG} -t ${VALIDATOR_REGISTRY}:${TAG}-${SHORT_SHA}"
           export CONTEXT_NAME="$RUNNER_NAME" && (docker context inspect "$CONTEXT_NAME" >/dev/null 2>&1 || docker context create "$CONTEXT_NAME")
-          docker buildx inspect validator || docker buildx create --name validator --driver-opt network=host --buildkitd-flags '--allow-insecure-entitlement security.insecure' "$CONTEXT_NAME"
-          docker buildx use validator
+          docker buildx inspect "validator-$RUNNER_NAME" || docker buildx create --name "validator-$RUNNER_NAME" --driver-opt network=host --buildkitd-flags '--allow-insecure-entitlement security.insecure' "$CONTEXT_NAME"
+          docker buildx use "validator-$RUNNER_NAME"
           ./docker.local/bin/build.validator.sh
 
 

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -89,7 +89,8 @@ jobs:
           export DOCKER_BUILD="buildx build --platform linux/amd64,linux/arm64 --push"
           export DOCKER_IMAGE_BLOBBER="-t ${BLOBBER_REGISTRY}:${TAG} -t ${BLOBBER_REGISTRY}:${TAG}-${SHORT_SHA}"
           export CONTEXT_NAME="$RUNNER_NAME" && (docker context inspect "$CONTEXT_NAME" >/dev/null 2>&1 || docker context create "$CONTEXT_NAME")
-          docker buildx create --driver-opt network=host --buildkitd-flags '--allow-insecure-entitlement security.insecure' --use "$CONTEXT_NAME"
+          docker buildx inspect blobber || docker buildx create --name blobber --driver-opt network=host --buildkitd-flags '--allow-insecure-entitlement security.insecure' "$CONTEXT_NAME"
+          docker buildx use blobber
           ./docker.local/bin/build.blobber.sh
 
   validator:
@@ -159,7 +160,8 @@ jobs:
           export DOCKER_BUILD="buildx build --platform linux/amd64,linux/arm64 --push"
           export DOCKER_IMAGE_VALIDATOR="-t ${VALIDATOR_REGISTRY}:${TAG} -t ${VALIDATOR_REGISTRY}:${TAG}-${SHORT_SHA}"
           export CONTEXT_NAME="$RUNNER_NAME" && (docker context inspect "$CONTEXT_NAME" >/dev/null 2>&1 || docker context create "$CONTEXT_NAME")
-          docker buildx create --driver-opt network=host --buildkitd-flags '--allow-insecure-entitlement security.insecure' --use "$CONTEXT_NAME"
+          docker buildx inspect validator || docker buildx create --name validator --driver-opt network=host --buildkitd-flags '--allow-insecure-entitlement security.insecure' "$CONTEXT_NAME"
+          docker buildx use validator
           ./docker.local/bin/build.validator.sh
 
 

--- a/.github/workflows/build-for-conductor-testing.yml
+++ b/.github/workflows/build-for-conductor-testing.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Cleanup before restarting conductor tests.
         run: |
           echo 'y' | docker system prune -a
-          rm -rf *
+          
           cd /tmp
           rm -rf ./*
       - name: Set docker image tag

--- a/.github/workflows/build-for-conductor-testing.yml
+++ b/.github/workflows/build-for-conductor-testing.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Cleanup before restarting conductor tests.
         run: |
           echo 'y' | docker system prune -a
-          
+          rm -rf *
           cd /tmp
           rm -rf ./*
       - name: Set docker image tag

--- a/.github/workflows/build-for-conductor-testing.yml
+++ b/.github/workflows/build-for-conductor-testing.yml
@@ -21,6 +21,12 @@ jobs:
   build_blobber_for_conductor_testing:
     runs-on: [self-hosted, arc-runner]
     steps:
+      - name: Cleanup before restarting conductor tests.
+        run: |
+          echo 'y' | docker system prune -a
+          rm -rf *
+          cd /tmp
+          rm -rf ./*
       - name: Set docker image tag
         run: |
           if [[ "${{github.ref}}" == refs/pull/* ]]; then


### PR DESCRIPTION
### Changes
1- Runs on a self-hosted Ubuntu machine which holds 4 runners
2- Create a docker context if not exist based on the runner name
3- Use docker actions for Docker Buildx
4- Increase blobber and validator job's timeout