### PR TITLE
fix(handler): idempotent DELETE on already-removed ref

### DIFF
--- a/code/go/0chain.net/blobbercore/handler/handler.go
+++ b/code/go/0chain.net/blobbercore/handler/handler.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 
+	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/allocation"
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/config"
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/datastore"
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/readmarker"
@@ -1558,6 +1559,15 @@ func uploadHandler(ctx context.Context, r *http.Request) (interface{}, error) {
 	ctx = setupHandlerContext(ctx, r)
 	response, err := storageHandler.WriteFile(ctx, r)
 	if err != nil {
+		// Idempotent DELETE: if the ref was already removed (e.g. implicit
+		// empty-directory cleanup after its last child was deleted, or a
+		// concurrent bulk-delete), the caller's intent is already satisfied
+		// — don't 400 them. Matches the existing pattern in commitHandler /
+		// rollbackHandler. Scope to DELETE so other methods still surface
+		// the error if they ever see it.
+		if r.Method == http.MethodDelete && errors.Is(err, common.ErrFileWasDeleted) {
+			return allocation.UploadResult{}, nil
+		}
 		Logger.Error("writeFileHandler", zap.Error(err))
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- When the last child of a directory is deleted, the blobber implicitly removes the now-empty directory's reference object. A subsequent DELETE on that directory (common in bulk-delete flows from the Vult UI) currently 400s because the GORM \`record not found\` from \`reference.go\` bubbles up as \`ErrFileWasDeleted\`.
- The upload handler — unlike \`commitHandler\` / \`rollbackHandler\` — didn't special-case this to idempotent success.
- Mirror the existing pattern: on DELETE, treat \`ErrFileWasDeleted\` as a no-op success (200 with empty \`UploadResult\`). Scoped to DELETE so other methods still surface the error.

## Repro
1. Upload a folder with subfolders + files in Vult.
2. Bulk-delete the top folder.
3. Browser console: many \`DELETE /v1/file/upload/… 400 (Bad Request)\` errors against the now-empty intermediate directories, even though all file data is correctly removed server-side.

## Test plan
- [ ] Build + run on a dev blobber, repeat the bulk-delete repro, confirm DELETE returns 200 for already-removed dirs.
- [ ] Verify non-DELETE methods (POST upload, PUT update) still 400 on \`ErrFileWasDeleted\` as before.
- [ ] Verify existing unit tests pass.