### PR TITLE
fix(delete): recursive directory delete for streaming-video dirs

### DIFF
--- a/code/go/0chain.net/blobbercore/allocation/deletefilechange.go
+++ b/code/go/0chain.net/blobbercore/allocation/deletefilechange.go
@@ -54,13 +54,38 @@ func (nf *DeleteFileChange) ApplyChangeV2(_ context.Context, _, _ string, numFil
 			return err
 		}
 		if ref.Type == reference.DIRECTORY {
-			isEmpty, err := reference.IsDirectoryEmpty(ctx, nf.AllocationID, nf.Path)
-			if err != nil {
-				logging.Logger.Error("deleted_object_error", zap.Error(err))
-				return err
+			// Recursively soft-delete descendant DIRECTORY refs instead of
+			// rejecting a non-empty directory. Root-neutral: the StorageV2
+			// merkle trie / allocation_root is built only from type=FILE refs
+			// (allocationchange.go ... WHERE type=FILE), so removing directory
+			// refs never changes the root and cannot diverge from the client's
+			// write marker.
+			//
+			// FILE descendants are intentionally NOT touched here — the gosdk
+			// client cascades file deletes itself (deleteworker.go
+			// deleteSubDirectories sends one delete op per descendant file,
+			// each carrying its own trie update). If the blobber also removed
+			// file descendants its root would diverge from the client's signed
+			// marker and the commit would be rejected. So the common
+			// streaming-video case (empty /file.mp4/preview dirs that diverged
+			// across blobbers) self-heals; a stray divergent FILE on a minority
+			// blobber still needs a client-driven delete.
+			db := datastore.GetStore().GetTransaction(ctx)
+			var descendantDirs []*reference.Ref
+			if derr := db.Model(&reference.Ref{}).
+				Select("id", "lookup_hash", "type").
+				Where("allocation_id=? AND type=? AND path LIKE ?",
+					nf.AllocationID, reference.DIRECTORY, nf.Path+"/%").
+				Find(&descendantDirs).Error; derr != nil {
+				logging.Logger.Error("deleted_object_error", zap.Error(derr))
+				return derr
 			}
-			if !isEmpty {
-				return common.NewError("invalid_reference_path", "directory is not empty")
+			for _, d := range descendantDirs {
+				collector.DeleteRefRecord(&reference.Ref{
+					ID:         d.ID,
+					LookupHash: d.LookupHash,
+					Type:       d.Type,
+				})
 			}
 		}
 		deleteRecord := &reference.Ref{

--- a/code/go/0chain.net/blobbercore/handler/file_command_delete.go
+++ b/code/go/0chain.net/blobbercore/handler/file_command_delete.go
@@ -6,13 +6,11 @@ import (
 	"net/http"
 
 	"github.com/0chain/gosdk/constants"
-	"go.uber.org/zap"
 	"gorm.io/gorm"
 
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/allocation"
 	"github.com/0chain/blobber/code/go/0chain.net/blobbercore/reference"
 	"github.com/0chain/blobber/code/go/0chain.net/core/common"
-	"github.com/0chain/blobber/code/go/0chain.net/core/logging"
 )
 
 // DeleteFileCommand command for deleting file
@@ -59,16 +57,11 @@ func (cmd *DeleteFileCommand) IsValidated(ctx context.Context, req *http.Request
 		}
 		return common.NewError("bad_db_operation", err.Error())
 	}
-	if allocationObj.IsStorageV2() && cmd.existingFileRef.Type == reference.DIRECTORY {
-		isEmpty, err := reference.IsDirectoryEmpty(ctx, allocationObj.ID, path)
-		if err != nil {
-			return err
-		}
-		if !isEmpty {
-			logging.Logger.Error("directory_not_empty", zap.String("path", path))
-			return common.NewError("invalid_reference_path", "directory is not empty")
-		}
-	}
+	// Non-empty directories are no longer rejected here. The recursive
+	// directory cleanup happens at commit time in DeleteFileChange.ApplyChangeV2
+	// (it soft-deletes descendant directory refs; file descendants are
+	// cascaded by the gosdk client). This upload-time guard would otherwise
+	// block that path and is the cause of the stuck streaming-video deletes.
 	cmd.existingFileRef.LookupHash = lookUpHash
 	return nil
 }


### PR DESCRIPTION
## Summary
Stacked on #1557 (idempotent delete). Makes StorageV2 directory delete **recursive** so the stuck streaming-video directories can be deleted.

A streaming video is stored as a directory tree (\`/file.mp4/\` + \`/file.mp4/preview/\`). When that structure diverges across blobbers (preview present on some, absent on others — happens during partial commit under load), every delete fails: blobbers reject with "directory is not empty" (have preview) or "record not found" (absent), consensus never reached.

## Change
- \`deletefilechange.go ApplyChangeV2\`: deleting a directory now recursively soft-deletes descendant **directory** refs instead of rejecting non-empty.
- \`file_command_delete.go\`: removed the upload-time "directory is not empty" guard (recursive work now happens at commit).

## Write-marker safety (verified)
The allocation merkle trie / \`allocation_root\` is built **only from \`type=FILE\` refs** (\`allocationchange.go\` \`WHERE type=FILE\`, \`entity.go\` trie.Update files only). Removing directory refs is **root-neutral** — cannot diverge from the client's signed write marker.

Scoped to **directory descendants only**. FILE descendants are left untouched because the gosdk client cascades file deletes itself (\`deleteworker.go deleteSubDirectories\` sends one delete op per descendant file with its own trie update). If the blobber also removed files, its root would diverge from the client's marker → commit rejected.

## Residual / follow-up
A stray divergent FILE on a minority blobber still needs a client-driven or repair-driven delete. The deeper fix (full-consensus directory create + repair reconciling directories) is in \`devOps/0chain-debug/directory-consistency-design.md\`.

## Incident
\`devOps/0chain-debug/streaming-video-delete-incident-20260602.md\`

## Test plan
- [ ] Build + deploy to a dev blobber; create a dir with a subdir, manually delete the subdir ref from one blobber's DB to simulate divergence, then delete the parent dir from the UI → should succeed on all blobbers.
- [ ] Verify a normal (consistent) nested-dir delete still works.
- [ ] Verify single-file delete + idempotent (#1557) behavior unchanged.