### PR TITLE
fix(util): return error from NewHTTPRequest before dereferencing nil req

### DIFF
--- a/code/go/0chain.net/core/util/http.go
+++ b/code/go/0chain.net/core/util/http.go
@@ -23,6 +23,9 @@ const SLEEP_BETWEEN_RETRIES = 5
 func NewHTTPRequest(method, url string, data []byte) (*http.Request, context.Context, context.CancelFunc, error) {
 	requestHash := encryption.Hash(data)
 	req, err := http.NewRequest(method, url, bytes.NewBuffer(data))
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	req.Header.Set("Access-Control-Allow-Origin", "*")
 	req.Header.Set("X-App-Client-ID", node.Self.ID)


### PR DESCRIPTION
NewHTTPRequest called req.Header.Set five times before checking the err returned by http.NewRequest, so a malformed URL or invalid method returned nil, err and the first Header.Set dereferenced a nil pointer and panicked. Return the error immediately when http.NewRequest fails, before touching req.